### PR TITLE
[global] JPA Entity 구현

### DIFF
--- a/src/main/java/team/themoment/readygsm/domain/activity/data/Activity.java
+++ b/src/main/java/team/themoment/readygsm/domain/activity/data/Activity.java
@@ -1,0 +1,45 @@
+package team.themoment.readygsm.domain.activity.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.themoment.readygsm.domain.activity.data.constant.ActivityType;
+import team.themoment.readygsm.domain.activity.entity.ActivityJpaEntity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Activity {
+    private Long id;
+    private String name;
+    private String image;
+    private Integer currentApplicant;
+    private Integer maxApplicant;
+    private ActivityType type;
+    private LocalDate date;
+    private String place;
+    private String major;
+    private LocalDateTime applicationStart;
+    private LocalDateTime applicationEnd;
+
+    public ActivityJpaEntity toEntity() {
+        return ActivityJpaEntity.builder()
+                .id(id)
+                .name(name)
+                .image(image)
+                .currentApplicant(currentApplicant)
+                .maxApplicant(maxApplicant)
+                .type(type)
+                .date(date)
+                .place(place)
+                .major(major)
+                .applicationStart(applicationStart)
+                .applicationEnd(applicationEnd)
+                .build();
+    }
+}

--- a/src/main/java/team/themoment/readygsm/domain/activity/data/constant/ActivityType.java
+++ b/src/main/java/team/themoment/readygsm/domain/activity/data/constant/ActivityType.java
@@ -1,0 +1,6 @@
+package team.themoment.readygsm.domain.activity.data.constant;
+
+public enum ActivityType {
+    MAJOR_TRIAL,
+    ADMISSION_INFO
+}

--- a/src/main/java/team/themoment/readygsm/domain/activity/entity/ActivityJpaEntity.java
+++ b/src/main/java/team/themoment/readygsm/domain/activity/entity/ActivityJpaEntity.java
@@ -1,0 +1,62 @@
+package team.themoment.readygsm.domain.activity.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.themoment.readygsm.domain.activity.data.Activity;
+import team.themoment.readygsm.domain.activity.data.constant.ActivityType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Table(name = "activity")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class ActivityJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "activity_id")
+    private Long id;
+    @Column(name = "activity_name", nullable = false)
+    private String name;
+    @Column(name = "activity_image")
+    private String image;
+    @Column(name = "activity_current_applicant", columnDefinition = "integer default 0")
+    private Integer currentApplicant;
+    @Column(name = "activity_max_applicant")
+    private Integer maxApplicant;
+    @Column(name = "activity_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ActivityType type;
+    @Column(name = "activity_date", nullable = false)
+    private LocalDate date;
+    @Column(name = "activity_place", nullable = false)
+    private String place;
+    @Column(name = "activity_major")
+    private String major;
+    @Column(name = "activity_application_start", nullable = false)
+    private LocalDateTime applicationStart;
+    @Column(name = "activity_application_end", nullable = false)
+    private LocalDateTime applicationEnd;
+
+    public Activity toDto() {
+        return Activity.builder()
+                .id(id)
+                .name(name)
+                .image(image)
+                .currentApplicant(currentApplicant)
+                .maxApplicant(maxApplicant)
+                .type(type)
+                .date(date)
+                .place(place)
+                .major(major)
+                .applicationStart(applicationStart)
+                .applicationEnd(applicationEnd)
+                .build();
+    }
+}

--- a/src/main/java/team/themoment/readygsm/domain/activity/repository/ActivityJpaRepository.java
+++ b/src/main/java/team/themoment/readygsm/domain/activity/repository/ActivityJpaRepository.java
@@ -1,0 +1,9 @@
+package team.themoment.readygsm.domain.activity.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import team.themoment.readygsm.domain.activity.entity.ActivityJpaEntity;
+
+@Repository
+public interface ActivityJpaRepository extends JpaRepository<ActivityJpaEntity, Integer> {
+}

--- a/src/main/java/team/themoment/readygsm/domain/reservation/data/Reservation.java
+++ b/src/main/java/team/themoment/readygsm/domain/reservation/data/Reservation.java
@@ -1,0 +1,39 @@
+package team.themoment.readygsm.domain.reservation.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.themoment.readygsm.domain.activity.data.Activity;
+import team.themoment.readygsm.domain.reservation.entity.ReservationJpaEntity;
+import team.themoment.readygsm.domain.user.data.User;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Reservation {
+    private Long id;
+    private Activity activityId;
+    private User userId;
+    private String phoneNumber;
+    private String schoolName;
+    private Integer grade;
+    private Integer classNumber;
+    private Integer studentNumber;
+    private String applicantName;
+
+    public ReservationJpaEntity toEntity() {
+        return ReservationJpaEntity.builder()
+                .id(id)
+                .activity(activityId.toEntity())
+                .user(userId.toEntity())
+                .phoneNumber(phoneNumber)
+                .schoolName(schoolName)
+                .grade(grade)
+                .classNumber(classNumber)
+                .studentNumber(studentNumber)
+                .applicantName(applicantName)
+                .build();
+    }
+}

--- a/src/main/java/team/themoment/readygsm/domain/reservation/entity/ReservationJpaEntity.java
+++ b/src/main/java/team/themoment/readygsm/domain/reservation/entity/ReservationJpaEntity.java
@@ -25,16 +25,16 @@ public class ReservationJpaEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private UserJpaEntity user;
-    @Column(name = "phone_number", nullable = false)
+    @Column(name = "reservation_phone_number", nullable = false)
     private String phoneNumber;
-    @Column(name="school_name", nullable = false)
+    @Column(name="reservation_school_name", nullable = false)
     private String schoolName;
-    @Column(name = "grade", nullable = false)
+    @Column(name = "reservation_grade", nullable = false)
     private Integer grade;
-    @Column(name = "class_number", nullable = false)
+    @Column(name = "reservation_class_number", nullable = false)
     private Integer classNumber;
-    @Column(name = "student_number", nullable = false)
+    @Column(name = "reservation_student_number", nullable = false)
     private Integer studentNumber;
-    @Column(name="applicant_name", nullable = false)
+    @Column(name="reservation_applicant_name", nullable = false)
     private String applicantName;
 }

--- a/src/main/java/team/themoment/readygsm/domain/reservation/entity/ReservationJpaEntity.java
+++ b/src/main/java/team/themoment/readygsm/domain/reservation/entity/ReservationJpaEntity.java
@@ -1,0 +1,40 @@
+package team.themoment.readygsm.domain.reservation.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.themoment.readygsm.domain.activity.entity.ActivityJpaEntity;
+import team.themoment.readygsm.domain.user.entity.UserJpaEntity;
+
+@Table(name = "reservation")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class ReservationJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_id")
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activity_id", nullable = false)
+    private ActivityJpaEntity activity;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserJpaEntity user;
+    @Column(name = "phone_number", nullable = false)
+    private String phoneNumber;
+    @Column(name="school_name", nullable = false)
+    private String schoolName;
+    @Column(name = "grade", nullable = false)
+    private Integer grade;
+    @Column(name = "class_number", nullable = false)
+    private Integer classNumber;
+    @Column(name = "student_number", nullable = false)
+    private Integer studentNumber;
+    @Column(name="applicant_name", nullable = false)
+    private String applicantName;
+}

--- a/src/main/java/team/themoment/readygsm/domain/reservation/repository/ReservationJpaRepository.java
+++ b/src/main/java/team/themoment/readygsm/domain/reservation/repository/ReservationJpaRepository.java
@@ -1,0 +1,9 @@
+package team.themoment.readygsm.domain.reservation.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import team.themoment.readygsm.domain.reservation.entity.ReservationJpaEntity;
+
+@Repository
+public interface ReservationJpaRepository extends JpaRepository<ReservationJpaEntity, Long> {
+}

--- a/src/main/java/team/themoment/readygsm/domain/user/data/User.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/data/User.java
@@ -1,0 +1,28 @@
+package team.themoment.readygsm.domain.user.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.themoment.readygsm.domain.user.data.constant.UserRole;
+import team.themoment.readygsm.domain.user.entity.UserJpaEntity;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+    private Long id;
+    private String email;
+    private String name;
+    private UserRole role;
+
+    public UserJpaEntity toEntity() {
+        return UserJpaEntity.builder()
+                .id(id)
+                .email(email)
+                .name(name)
+                .role(role)
+                .build();
+    }
+}

--- a/src/main/java/team/themoment/readygsm/domain/user/data/constant/UserRole.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/data/constant/UserRole.java
@@ -1,0 +1,20 @@
+package team.themoment.readygsm.domain.user.data.constant;
+
+import org.springframework.security.core.GrantedAuthority;
+
+public enum UserRole implements GrantedAuthority {
+    ADMIN("ROLE_ADMIN"),
+    USER("ROLE_USER"),
+    TEACHER("ROLE_TEACHER");
+
+    private final String authority;
+
+    UserRole(String authority) {
+        this.authority = authority;
+    }
+
+    @Override
+    public String getAuthority() {
+        return authority;
+    }
+}

--- a/src/main/java/team/themoment/readygsm/domain/user/entity/UserJpaEntity.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/entity/UserJpaEntity.java
@@ -18,11 +18,11 @@ public class UserJpaEntity {
     @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long id;
-    @Column(name = "email", nullable = false, unique = true)
+    @Column(name = "user_email", nullable = false, unique = true)
     private String email;
-    @Column(name = "name", nullable = false)
+    @Column(name = "user_name", nullable = false)
     private String name;
-    @Column(name = "role", nullable = false)
+    @Column(name = "user_role", nullable = false)
     @Enumerated(EnumType.STRING)
     private UserRole role;
 

--- a/src/main/java/team/themoment/readygsm/domain/user/entity/UserJpaEntity.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/entity/UserJpaEntity.java
@@ -1,0 +1,37 @@
+package team.themoment.readygsm.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.themoment.readygsm.domain.user.data.constant.UserRole;
+
+@Table(name = "user")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class UserJpaEntity {
+    @Id
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+    @Column(name = "name", nullable = false)
+    private String name;
+    @Column(name = "role", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    public UserJpaEntity toDto() {
+        return UserJpaEntity.builder()
+                .id(id)
+                .email(email)
+                .name(name)
+                .role(role)
+                .build();
+    }
+}

--- a/src/main/java/team/themoment/readygsm/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/repository/UserJpaRepository.java
@@ -1,0 +1,9 @@
+package team.themoment.readygsm.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import team.themoment.readygsm.domain.reservation.entity.ReservationJpaEntity;
+
+@Repository
+public interface UserJpaRepository extends JpaRepository<ReservationJpaEntity, Long> {
+}


### PR DESCRIPTION
## 개요

> [ERD](https://www.erdcloud.com/d/ordJBbaukG3P5G7cX)에 알맞게 JPA Entity,Repository를 구현하였습니다

<img width="976" alt="image" src="https://github.com/user-attachments/assets/c7630ddf-894c-41d0-8f10-5c7e1d41fb6f" />


## 본문

> ``User``,``Reservation``,``Activity`` 와 같은 도메인에 각각 JPA Entity,Repository와 기본적으로 Entity와 동일한 구조를 가지는 DTO를 생성하였습니다