### PR TITLE
[reservation] 요구사항에 맞지않는 제약조건 적용 수정

### DIFF
--- a/src/main/java/team/themoment/readygsm/domain/reservation/entity/ReservationJpaEntity.java
+++ b/src/main/java/team/themoment/readygsm/domain/reservation/entity/ReservationJpaEntity.java
@@ -27,13 +27,13 @@ public class ReservationJpaEntity {
     private UserJpaEntity user;
     @Column(name = "reservation_phone_number", nullable = false)
     private String phoneNumber;
-    @Column(name="reservation_school_name", nullable = false)
+    @Column(name="reservation_school_name")
     private String schoolName;
-    @Column(name = "reservation_grade", nullable = false)
+    @Column(name = "reservation_grade")
     private Integer grade;
-    @Column(name = "reservation_class_number", nullable = false)
+    @Column(name = "reservation_class_number")
     private Integer classNumber;
-    @Column(name = "reservation_student_number", nullable = false)
+    @Column(name = "reservation_student_number")
     private Integer studentNumber;
     @Column(name="reservation_applicant_name", nullable = false)
     private String applicantName;


### PR DESCRIPTION
## 개요

요구사항에 따라 예약 정보를 저장하는 JPA Entity(``ReservationJpaEntity``)에서는 학생 정보 필드들이 Nullable이지만 Not Null 설정이 되어 있던 문제를 수정하였습니다

## 본문
학교명(``schoolName``),학년(``grade``),학급(``classNumber``),번호(``studentNumber``) 필드에 Not Null 제약조건을 해제하였습니다
### 피드백

추가적으로 더 변경이 필요한 필드가 있다면 살펴봐주시고 피드백해주시길 바랍니다