### PR TITLE
[global] 전역 예외 처리 기능 구현

### DIFF
--- a/src/main/java/team/themoment/readygsm/global/error/ErrorCode.java
+++ b/src/main/java/team/themoment/readygsm/global/error/ErrorCode.java
@@ -1,0 +1,15 @@
+package team.themoment.readygsm.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value());
+
+    private final String message;
+    private final int status;
+}

--- a/src/main/java/team/themoment/readygsm/global/error/data/response/ErrorResponse.java
+++ b/src/main/java/team/themoment/readygsm/global/error/data/response/ErrorResponse.java
@@ -1,0 +1,4 @@
+package team.themoment.readygsm.global.error.data.response;
+
+public record ErrorResponse(String message, int httpStatus) {
+}

--- a/src/main/java/team/themoment/readygsm/global/error/exception/ExpectedException.java
+++ b/src/main/java/team/themoment/readygsm/global/error/exception/ExpectedException.java
@@ -4,10 +4,10 @@ import lombok.Getter;
 import team.themoment.readygsm.global.error.ErrorCode;
 
 @Getter
-public class ReadyGsmException extends RuntimeException {
+public class ExpectedException extends RuntimeException {
     private final ErrorCode errorCode;
 
-    public ReadyGsmException(ErrorCode errorCode) {
+    public ExpectedException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }

--- a/src/main/java/team/themoment/readygsm/global/error/exception/ReadyGsmException.java
+++ b/src/main/java/team/themoment/readygsm/global/error/exception/ReadyGsmException.java
@@ -1,0 +1,14 @@
+package team.themoment.readygsm.global.error.exception;
+
+import lombok.Getter;
+import team.themoment.readygsm.global.error.ErrorCode;
+
+@Getter
+public class ReadyGsmException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public ReadyGsmException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/team/themoment/readygsm/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/team/themoment/readygsm/global/error/handler/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package team.themoment.readygsm.global.error.handler;
+
+import jakarta.persistence.NonUniqueResultException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import team.themoment.readygsm.global.error.data.response.ErrorResponse;
+import team.themoment.readygsm.global.error.exception.ReadyGsmException;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ReadyGsmException.class)
+    public ResponseEntity<ErrorResponse> handleReadyGsmException(ReadyGsmException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(new ErrorResponse(e.getErrorCode().getMessage(), e.getErrorCode().getStatus()));
+    }
+
+    @ExceptionHandler(NonUniqueResultException.class)
+    public ResponseEntity<ErrorResponse> handleNonUniqueResultException(NonUniqueResultException e) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse("요청에 대한 결과가 중복되었습니다.", HttpStatus.CONFLICT.value()));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("데이터 무결성을 위반하는 요청입니다.", HttpStatus.BAD_REQUEST.value()));
+    }
+}

--- a/src/main/java/team/themoment/readygsm/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/team/themoment/readygsm/global/error/handler/GlobalExceptionHandler.java
@@ -7,13 +7,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import team.themoment.readygsm.global.error.data.response.ErrorResponse;
-import team.themoment.readygsm.global.error.exception.ReadyGsmException;
+import team.themoment.readygsm.global.error.exception.ExpectedException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(ReadyGsmException.class)
-    public ResponseEntity<ErrorResponse> handleReadyGsmException(ReadyGsmException e) {
+    @ExceptionHandler(ExpectedException.class)
+    public ResponseEntity<ErrorResponse> handleExpectedException(ExpectedException e) {
         return ResponseEntity
                 .status(e.getErrorCode().getStatus())
                 .body(new ErrorResponse(e.getErrorCode().getMessage(), e.getErrorCode().getStatus()));


### PR DESCRIPTION
## 개요

> 애플리케이션에서 커스텀 예외를 발행하여 이를 핸들링할 수 있도록 기능을 구현하였습니다

## 본문
> 커스텀 예외의 경우 ``ErrorCode`` Enum 클래스에 정의 후 예외 클래스를 생성하여 구현하면 되며 일부 DB 관련 예외 역시 핸들링 하였습니다
### 피드백

> 커스텀 예외 클래스명을 ``ReadyGsmException``으로 하였는데 더 적절한 네이밍이 있다면 한번 피드백 해주시면 감사하겠습니다!