### PR TITLE
[global] 임시 개발용 보안 설정 구현

### DIFF
--- a/src/main/java/team/themoment/readygsm/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/themoment/readygsm/global/security/config/SecurityConfig.java
@@ -1,0 +1,21 @@
+package team.themoment.readygsm.global.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable);
+        return http.build();
+    }
+}


### PR DESCRIPTION
## 개요

> CSRF,CORS,기본 로그인을 비활성화 하는 설정을 구성하였습니다
## 본문

> Spring Security의 기본 설정이 활성화 되어 보안 기능이 구현될 때까지 인증/인가 기본 설정으로 인하여 개발 진행에 문제가 생기지 않도록 설정들을 비활성화 하였습니다