### PR TITLE
[user] 사용자 도메인 모델 API 구현

### DIFF
--- a/src/main/java/team/themoment/readygsm/domain/reservation/entity/ReservationJpaEntity.java
+++ b/src/main/java/team/themoment/readygsm/domain/reservation/entity/ReservationJpaEntity.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.themoment.readygsm.domain.activity.entity.ActivityJpaEntity;
+import team.themoment.readygsm.domain.reservation.data.Reservation;
 import team.themoment.readygsm.domain.user.entity.UserJpaEntity;
 
 @Table(name = "reservation")
@@ -37,4 +38,18 @@ public class ReservationJpaEntity {
     private Integer studentNumber;
     @Column(name="reservation_applicant_name", nullable = false)
     private String applicantName;
+
+    public Reservation toDto() {
+        return Reservation.builder()
+                .id(id)
+                .activityId(activity.toDto())
+                .userId(user.toDto())
+                .phoneNumber(phoneNumber)
+                .schoolName(schoolName)
+                .grade(grade)
+                .classNumber(classNumber)
+                .studentNumber(studentNumber)
+                .applicantName(applicantName)
+                .build();
+    }
 }

--- a/src/main/java/team/themoment/readygsm/domain/reservation/repository/ReservationJpaRepository.java
+++ b/src/main/java/team/themoment/readygsm/domain/reservation/repository/ReservationJpaRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import team.themoment.readygsm.domain.reservation.entity.ReservationJpaEntity;
 
+import java.util.List;
+
 @Repository
 public interface ReservationJpaRepository extends JpaRepository<ReservationJpaEntity, Long> {
+    List<ReservationJpaEntity> findByUserId(Long userId);
 }

--- a/src/main/java/team/themoment/readygsm/domain/reservation/repository/ReservationJpaRepository.java
+++ b/src/main/java/team/themoment/readygsm/domain/reservation/repository/ReservationJpaRepository.java
@@ -1,6 +1,7 @@
 package team.themoment.readygsm.domain.reservation.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import team.themoment.readygsm.domain.reservation.entity.ReservationJpaEntity;
 
@@ -8,5 +9,8 @@ import java.util.List;
 
 @Repository
 public interface ReservationJpaRepository extends JpaRepository<ReservationJpaEntity, Long> {
+    @Query("SELECT r FROM ReservationJpaEntity r JOIN FETCH r.activity WHERE r.user.id = :userId")
     List<ReservationJpaEntity> findByUserId(Long userId);
+    @Query("SELECT r FROM ReservationJpaEntity r JOIN FETCH r.activity WHERE r.user.id IN :userIds")
+    List<ReservationJpaEntity> findByUserIdIn(List<Long> userIds);
 }

--- a/src/main/java/team/themoment/readygsm/domain/user/entity/UserJpaEntity.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/entity/UserJpaEntity.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team.themoment.readygsm.domain.user.data.User;
 import team.themoment.readygsm.domain.user.data.constant.UserRole;
 
 @Table(name = "user")
@@ -26,8 +27,8 @@ public class UserJpaEntity {
     @Enumerated(EnumType.STRING)
     private UserRole role;
 
-    public UserJpaEntity toDto() {
-        return UserJpaEntity.builder()
+    public User toDto() {
+        return User.builder()
                 .id(id)
                 .email(email)
                 .name(name)

--- a/src/main/java/team/themoment/readygsm/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package team.themoment.readygsm.domain.user.exception;
+
+import team.themoment.readygsm.global.error.ErrorCode;
+import team.themoment.readygsm.global.error.exception.ExpectedException;
+
+public class UserNotFoundException extends ExpectedException {
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/team/themoment/readygsm/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/presentation/controller/UserController.java
@@ -3,15 +3,13 @@ package team.themoment.readygsm.domain.user.presentation.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import team.themoment.readygsm.domain.user.data.constant.UserRole;
 import team.themoment.readygsm.domain.user.presentation.data.response.GetUserResDto;
 import team.themoment.readygsm.domain.user.service.FindUserService;
 
 import java.util.ArrayList;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,5 +27,18 @@ public class UserController {
     public ResponseEntity<GetUserResDto> getCurrentUser() {
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(new GetUserResDto(
                 1L, "Test User", "s00000@gsm.hs.kr", UserRole.USER, new ArrayList<>()));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<GetUserResDto>> searchUsers(
+            @RequestParam(value = "name", required = false) String name,
+            @RequestParam(value = "schoolName", required = false) String schoolName,
+            @RequestParam(value = "grade", required = false) Integer grade,
+            @RequestParam(value = "classNumber", required = false) Integer classNumber,
+            @RequestParam(value = "number", required = false) Integer number,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "limit", defaultValue = "255") int limit
+    ) {
+
     }
 }

--- a/src/main/java/team/themoment/readygsm/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/presentation/controller/UserController.java
@@ -1,0 +1,33 @@
+package team.themoment.readygsm.domain.user.presentation.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team.themoment.readygsm.domain.user.data.constant.UserRole;
+import team.themoment.readygsm.domain.user.presentation.data.response.GetUserResDto;
+import team.themoment.readygsm.domain.user.service.FindUserService;
+
+import java.util.ArrayList;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserController {
+
+    private final FindUserService findUserService;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<GetUserResDto> getUser(@PathVariable(value = "userId") Long userId) {
+        return ResponseEntity.status(HttpStatus.OK).body(findUserService.execute(userId));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<GetUserResDto> getCurrentUser() {
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(new GetUserResDto(
+                1L, "Test User", "s00000@gsm.hs.kr", UserRole.USER, new ArrayList<>()));
+    }
+}

--- a/src/main/java/team/themoment/readygsm/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/presentation/controller/UserController.java
@@ -6,7 +6,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.themoment.readygsm.domain.user.data.constant.UserRole;
 import team.themoment.readygsm.domain.user.presentation.data.response.GetUserResDto;
+import team.themoment.readygsm.domain.user.presentation.data.response.PatchUserResDto;
 import team.themoment.readygsm.domain.user.service.FindUserService;
+import team.themoment.readygsm.domain.user.service.ModifyUserService;
 import team.themoment.readygsm.domain.user.service.SearchUserService;
 
 import java.util.ArrayList;
@@ -19,6 +21,7 @@ public class UserController {
 
     private final FindUserService findUserService;
     private final SearchUserService searchUserService;
+    private final ModifyUserService modifyUserService;
 
     @GetMapping("/{userId}")
     public ResponseEntity<GetUserResDto> getUser(@PathVariable(value = "userId") Long userId) {
@@ -41,5 +44,14 @@ public class UserController {
     ) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(searchUserService.execute(name, email, role, page, limit));
+    }
+
+    @PatchMapping("/{userId}")
+    public ResponseEntity<PatchUserResDto> updateUser(
+            @PathVariable(value = "userId") Long userId,
+            @RequestParam(value = "name", required = false) String name,
+            @RequestParam(value = "email", required = false) String email
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(modifyUserService.execute(userId, name, email));
     }
 }

--- a/src/main/java/team/themoment/readygsm/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/presentation/controller/UserController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import team.themoment.readygsm.domain.user.data.constant.UserRole;
 import team.themoment.readygsm.domain.user.presentation.data.response.GetUserResDto;
 import team.themoment.readygsm.domain.user.service.FindUserService;
+import team.themoment.readygsm.domain.user.service.SearchUserService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +18,7 @@ import java.util.List;
 public class UserController {
 
     private final FindUserService findUserService;
+    private final SearchUserService searchUserService;
 
     @GetMapping("/{userId}")
     public ResponseEntity<GetUserResDto> getUser(@PathVariable(value = "userId") Long userId) {
@@ -32,13 +34,12 @@ public class UserController {
     @GetMapping("/search")
     public ResponseEntity<List<GetUserResDto>> searchUsers(
             @RequestParam(value = "name", required = false) String name,
-            @RequestParam(value = "schoolName", required = false) String schoolName,
-            @RequestParam(value = "grade", required = false) Integer grade,
-            @RequestParam(value = "classNumber", required = false) Integer classNumber,
-            @RequestParam(value = "number", required = false) Integer number,
+            @RequestParam(value = "email", required = false) String email,
+            @RequestParam(value = "role", required = false) UserRole role,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "limit", defaultValue = "255") int limit
     ) {
-
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(searchUserService.execute(name, email, role, page, limit));
     }
 }

--- a/src/main/java/team/themoment/readygsm/domain/user/presentation/data/response/GetUserResDto.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/presentation/data/response/GetUserResDto.java
@@ -1,0 +1,15 @@
+package team.themoment.readygsm.domain.user.presentation.data.response;
+
+import team.themoment.readygsm.domain.reservation.data.Reservation;
+import team.themoment.readygsm.domain.user.data.constant.UserRole;
+
+import java.util.List;
+
+public record GetUserResDto(
+        Long userId,
+        String name,
+        String email,
+        UserRole role,
+        List<Reservation> reservations
+) {
+}

--- a/src/main/java/team/themoment/readygsm/domain/user/presentation/data/response/PatchUserResDto.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/presentation/data/response/PatchUserResDto.java
@@ -1,0 +1,7 @@
+package team.themoment.readygsm.domain.user.presentation.data.response;
+
+public record PatchUserResDto(
+        String email,
+        String name
+) {
+}

--- a/src/main/java/team/themoment/readygsm/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/repository/UserJpaRepository.java
@@ -1,9 +1,24 @@
 package team.themoment.readygsm.domain.user.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import team.themoment.readygsm.domain.user.data.constant.UserRole;
 import team.themoment.readygsm.domain.user.entity.UserJpaEntity;
 
 @Repository
 public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
+    @Query("SELECT u FROM UserJpaEntity u WHERE " +
+            "(:name IS NULL OR :name = '' OR u.name LIKE %:name%) AND " +
+            "(:email IS NULL OR :email = '' OR u.email LIKE %:email%) AND " +
+            "(:role IS NULL OR u.role = :role)")
+    Page<UserJpaEntity> findByNameContainingAndEmailContainingAndRole(
+            @Param("name") String name,
+            @Param("email") String email,
+            @Param("role") UserRole role,
+            Pageable pageable
+    );
 }

--- a/src/main/java/team/themoment/readygsm/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/repository/UserJpaRepository.java
@@ -2,8 +2,8 @@ package team.themoment.readygsm.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import team.themoment.readygsm.domain.reservation.entity.ReservationJpaEntity;
+import team.themoment.readygsm.domain.user.entity.UserJpaEntity;
 
 @Repository
-public interface UserJpaRepository extends JpaRepository<ReservationJpaEntity, Long> {
+public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
 }

--- a/src/main/java/team/themoment/readygsm/domain/user/service/FindUserService.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/service/FindUserService.java
@@ -1,0 +1,32 @@
+package team.themoment.readygsm.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.readygsm.domain.reservation.entity.ReservationJpaEntity;
+import team.themoment.readygsm.domain.reservation.repository.ReservationJpaRepository;
+import team.themoment.readygsm.domain.user.exception.UserNotFoundException;
+import team.themoment.readygsm.domain.user.presentation.data.response.GetUserResDto;
+import team.themoment.readygsm.domain.user.repository.UserJpaRepository;
+
+@Service
+@RequiredArgsConstructor
+public class FindUserService {
+
+    private final UserJpaRepository userJpaRepository;
+    private final ReservationJpaRepository reservationJpaRepository;
+
+    public GetUserResDto execute(Long userId) {
+        return userJpaRepository.findById(userId)
+                .map(user -> new GetUserResDto(
+                        user.getId(),
+                        user.getName(),
+                        user.getEmail(),
+                        user.getRole(),
+                        reservationJpaRepository.findByUserId(userId)
+                                .stream()
+                                .map(ReservationJpaEntity::toDto)
+                                .toList()
+                ))
+                .orElseThrow(UserNotFoundException::new);
+    }
+}

--- a/src/main/java/team/themoment/readygsm/domain/user/service/ModifyUserService.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/service/ModifyUserService.java
@@ -1,0 +1,32 @@
+package team.themoment.readygsm.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.readygsm.domain.user.data.User;
+import team.themoment.readygsm.domain.user.exception.UserNotFoundException;
+import team.themoment.readygsm.domain.user.presentation.data.response.PatchUserResDto;
+import team.themoment.readygsm.domain.user.repository.UserJpaRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ModifyUserService {
+
+    private final UserJpaRepository userJpaRepository;
+
+    public PatchUserResDto execute(Long userId, String name, String email) {
+        // TODO:사용자 Role이 ADMIN이 아니라면 다른 사용자의 정보를 수정할 수 없도록 추가 구현 필요
+        User user = userJpaRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new)
+                .toDto();
+
+        userJpaRepository.save(User.builder()
+                .id(user.getId())
+                .name(name != null ? name : user.getName())
+                .email(email != null ? email : user.getEmail())
+                .role(user.getRole())
+                .build()
+                .toEntity()
+        );
+        return new PatchUserResDto(user.getName(), user.getEmail());
+    }
+}

--- a/src/main/java/team/themoment/readygsm/domain/user/service/SearchUserService.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/service/SearchUserService.java
@@ -1,0 +1,7 @@
+package team.themoment.readygsm.domain.user.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class SearchUserService {
+}

--- a/src/main/java/team/themoment/readygsm/domain/user/service/SearchUserService.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/service/SearchUserService.java
@@ -1,7 +1,58 @@
 package team.themoment.readygsm.domain.user.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import team.themoment.readygsm.domain.reservation.data.Reservation;
+import team.themoment.readygsm.domain.reservation.entity.ReservationJpaEntity;
+import team.themoment.readygsm.domain.reservation.repository.ReservationJpaRepository;
+import team.themoment.readygsm.domain.user.data.User;
+import team.themoment.readygsm.domain.user.data.constant.UserRole;
+import team.themoment.readygsm.domain.user.entity.UserJpaEntity;
+import team.themoment.readygsm.domain.user.presentation.data.response.GetUserResDto;
+import team.themoment.readygsm.domain.user.repository.UserJpaRepository;
+
+import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class SearchUserService {
+
+    private final UserJpaRepository userJpaRepository;
+    private final ReservationJpaRepository reservationJpaRepository;
+
+    public List<GetUserResDto> execute(
+            String name,
+            String email,
+            UserRole role,
+            int page,
+            int limit
+    ) {
+        List<User> users = userJpaRepository.findByNameContainingAndEmailContainingAndRole(
+                        name, email, role, PageRequest.of(page, limit)
+                )
+                .stream()
+                .map(UserJpaEntity::toDto)
+                .toList();
+        List<Reservation> reservations = reservationJpaRepository.findByUserIdIn(
+                        users.stream().map(User::getId).toList()
+                )
+                .stream()
+                .map(ReservationJpaEntity::toDto)
+                .toList();
+        return users.stream()
+                .map(user -> {
+                    List<Reservation> userReservations = reservations.stream()
+                            .filter(reservation -> reservation.getUserId().getId().equals(user.getId()))
+                            .toList();
+                    return new GetUserResDto(
+                            user.getId(),
+                            user.getName(),
+                            user.getEmail(),
+                            user.getRole(),
+                            userReservations
+                    );
+                })
+                .toList();
+    }
 }


### PR DESCRIPTION
## 개요

> 사용자 도메인에서 사용자 정보를 조회 및 수정하는 API을 구현하였습니다

## 본문

> ``GET /api/v1/users/me``와 ``PATCH /api/v1/users/{userId}`` 2가지 API는 현재 인증된 사용자 정보를 불러오는 기능이 필요하여 @hongjm0912님이 인증/인가 부분을 구현할 때까지 작업하지 않고 임시로 정의만 해두거나 기능이 미완성인 상태입니다. 그 외에 ``GET /api/v1/users/{userId}``와 ``GET /api/v1/users/search`` API를 구현하였습니다.

### 피드백

> 특히나 DTO나 서비스 클래스들의 네이밍을 자세히 봐주세요.해당 PR에서 작업된 내용과 같이 앞으로 전체 애플리케이션에서 네이밍을 맞춰나가야 하기 때문에 네이밍 컨벤션을 확정하는 것이 좋을 것 같습니다.또한, 사용자들을 조회하는 과정에서 JOIN 쿼리를 활용하고 프로젝션 기반 쿼리로 변경한다면 1회 쿼리 만으로 필요한 정보들을 가져올 수 있을 것 같지만 추가적인 DTO 정의와 쿼리 생성의 복잡성으로 현재 2회에 걸쳐 쿼리하여 가져오도록 하였는데 해당 방식에 대한 의견 있으시면 제시해 주시면 좋겠습니다!

### 기타

> Fetch Join을 통하여 JPA N+1 문제를 해결하였습니다.