### PR TITLE
[global] Swagger 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	/* Database */
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	/* Swagger */
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
 	/* Testing */
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/team/themoment/readygsm/global/config/SwaggerConfig.java
+++ b/src/main/java/team/themoment/readygsm/global/config/SwaggerConfig.java
@@ -1,0 +1,65 @@
+package team.themoment.readygsm.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import lombok.SneakyThrows;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import team.themoment.readygsm.global.response.CommonApiResponse;
+
+@OpenAPIDefinition(
+        info = @Info(title = "Ready, GSM",
+                description = "광주소프트웨어마이스터고 교외참여활동 관리 서비스",
+                version = "v1"))
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public GroupedOpenApi api(OperationCustomizer operationCustomizer) {
+        return GroupedOpenApi.builder()
+                .group("Ready, GSM API")
+                .pathsToMatch("/users/**", "/auth/**", "/reservation/**", "/activity/**")
+                .addOperationCustomizer(operationCustomizer)
+                .build();
+    }
+
+    @Bean
+    public OperationCustomizer operationCustomizer() {
+        return (operation, handlerMethod) -> {
+            Class<?> returnType = handlerMethod.getMethod().getReturnType();
+            this.addResponseBodyWrapperSchemaExample(operation, CommonApiResponse.class.isAssignableFrom(returnType));
+
+            return operation;
+        };
+    }
+
+    private void addResponseBodyWrapperSchemaExample(Operation operation, boolean hideDataField) {
+        final Content content = operation.getResponses().get("200").getContent();
+        if (content != null) {
+            content.keySet()
+                    .forEach(mediaTypeKey -> {
+                        final MediaType mediaType = content.get(mediaTypeKey);
+                        Schema<?> originalSchema = mediaType.getSchema();
+                        mediaType.schema(wrapSchema(originalSchema, hideDataField));
+                    });
+        }
+    }
+
+    @SneakyThrows
+    private Schema<?> wrapSchema(Schema<?> originalSchema, boolean hideDataField) {
+        final Schema<?> wrapperSchema = new Schema<>();
+
+        wrapperSchema.addProperty("status", new Schema<>().type("string").example("OK"));
+        wrapperSchema.addProperty("code", new Schema<>().type("integer").example(200));
+        wrapperSchema.addProperty("message", new Schema<>().type("string").example("OK"));
+        if (!hideDataField) wrapperSchema.addProperty("data", originalSchema);
+
+        return wrapperSchema;
+    }
+}

--- a/src/main/java/team/themoment/readygsm/global/response/CommonApiResponse.java
+++ b/src/main/java/team/themoment/readygsm/global/response/CommonApiResponse.java
@@ -1,0 +1,37 @@
+package team.themoment.readygsm.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nonnull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonApiResponse<T> {
+
+    @Schema(description = "상태 메시지", nullable = false, example = "OK")
+    HttpStatus status;
+    @Schema(description = "상태 코드", nullable = false, example = "200")
+    int code;
+    @Schema(description = "메시지", nullable = false, example = "완료되었습니다.")
+    String message;
+    @Schema(description = "데이터", nullable = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    T data;
+
+    public static CommonApiResponse success(@Nonnull String message) {
+        return new CommonApiResponse(HttpStatus.OK, HttpStatus.OK.value(), message, null);
+    }
+
+    public static CommonApiResponse created(@Nonnull String message) {
+        return new CommonApiResponse(HttpStatus.CREATED, HttpStatus.CREATED.value(), message, null);
+    }
+
+    public static CommonApiResponse error(@Nonnull String message, @Nonnull HttpStatus status) {
+        return new CommonApiResponse(status, status.value(), message, null);
+    }
+}

--- a/src/main/java/team/themoment/readygsm/global/response/wrapper/ApiResponseWrapper.java
+++ b/src/main/java/team/themoment/readygsm/global/response/wrapper/ApiResponseWrapper.java
@@ -1,0 +1,93 @@
+package team.themoment.readygsm.global.response.wrapper;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import team.themoment.readygsm.global.response.CommonApiResponse;
+
+import java.util.Arrays;
+import java.util.Map;
+
+@RestControllerAdvice
+public class ApiResponseWrapper implements ResponseBodyAdvice<Object> {
+
+    private static final String[] NOT_WRAPPING_URL = {
+            "/api-docs/**",
+    };
+
+    private final AntPathMatcher matcher = new AntPathMatcher();
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            MethodParameter returnType,
+            MediaType selectedContentType,
+            Class<? extends HttpMessageConverter<?>> selectedConverterType,
+            ServerHttpRequest request, ServerHttpResponse response) {
+
+        if (isNotWrappingURL(request.getURI().getPath())) {
+            return body;
+        }
+
+        if (body instanceof CommonApiResponse<?>) {
+            return byPassResponse(body, response);
+        }
+
+        if (body instanceof Map) {
+            Map<String, Object> bodyMap = (Map<String, Object>) body;
+            CommonApiResponse<Object> errorResponse = exceptionResponse(response, bodyMap);
+            if (errorResponse != null) return errorResponse;
+        }
+
+        if (body == null) {
+            response.setStatusCode(HttpStatus.NO_CONTENT);
+            return null;
+        }
+
+        CommonApiResponse<Object> commonApiResponse = new CommonApiResponse<>(
+                HttpStatus.OK,
+                HttpStatus.OK.value(),
+                "OK",
+                body
+        );
+
+        response.setStatusCode(HttpStatus.OK);
+        return commonApiResponse;
+    }
+
+    private static Object byPassResponse(Object body, ServerHttpResponse response) {
+        CommonApiResponse<?> commonApiMessageResponse = (CommonApiResponse<?>) body;
+        response.setStatusCode(commonApiMessageResponse.getStatus());
+        return body;
+    }
+
+    private static CommonApiResponse<Object> exceptionResponse(ServerHttpResponse response, Map<String, Object> bodyMap) {
+        if (bodyMap.containsKey("status")) {
+            int statusCode = (int) bodyMap.get("status");
+            if (statusCode >= 400 && statusCode < 600) {
+                HttpStatus status = HttpStatus.valueOf(statusCode);
+                CommonApiResponse<Object> errorResponse = CommonApiResponse.error(status.getReasonPhrase(), status);
+                response.setStatusCode(HttpStatusCode.valueOf(statusCode));
+                return errorResponse;
+            }
+        }
+        return null;
+    }
+
+    private boolean isNotWrappingURL(String requestURI) {
+        return Arrays.stream(NOT_WRAPPING_URL)
+                .anyMatch(pattern -> matcher.match(pattern, requestURI));
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,11 +20,6 @@ spring:
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
 
-  sql:
-    init:
-      mode: always
-
-
 springdoc:
   api-docs:
     path: /api-docs

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,3 +19,24 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
+
+  sql:
+    init:
+      mode: always
+
+
+springdoc:
+  api-docs:
+    path: /api-docs
+    groups:
+      enabled: true
+  swagger-ui:
+    enabled: true
+    disable-swagger-default-url: true
+    display-request-duration: true
+    tags-sorter: alpha
+    operations-sorter: method
+  show-actuator: true
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  writer-with-default-pretty-printer: true


### PR DESCRIPTION
## 개요

> 일관된 응답 구성을 위해서 ``CommonApiResponse``와 Wrapper 클래스를 구현하였으며 이를 기반으로 API 문서를 제공하는 Swagger를 구성하였습니다

## 본문

> 클라이언트에 일관된 응답을 제공하도록 API 응답을 가로채어 재구성 후 반환하는 기능을 추가하였고 그로 인한 변경된 반환 형식을 클라이언트에게 빠르게 전파하기 위하여 Swagger를 도입하였습니다

### 사용방법

> 기존에 반환형이 ``ResponseEntity<Void>`` 와 같은 형식이었다면 반환형을 ``CommonApiResponse``로 변경하여 주시고 별도의 응답 DTO를 정의하여 구현된 API라면 해당 DTO를 ``ResponseEntity<>``없이 바로 반환하도록 구성해주세요, HelloGSM의 컨트롤러 구성을 참고하셔도 될 것 같습니다