### PR TITLE
[user] 사용자 도메인 Swagger 문서화 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,61 +1,61 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.3'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'team.themoment'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	/* Spring Boot Starters */
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    /* Spring Boot Starters */
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-	/* Lombok */
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    /* Lombok */
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	/* Docker Compose Support */
-	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
+    /* Docker Compose Support */
+    developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 
-	/* Database */
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    /* Database */
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	/* Swagger */
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    /* Swagger */
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
-	/* Testing */
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    /* Testing */
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	/* Jwt */
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    /* Jwt */
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/team/themoment/readygsm/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/team/themoment/readygsm/domain/user/presentation/controller/UserController.java
@@ -1,5 +1,10 @@
 package team.themoment.readygsm.domain.user.presentation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,26 +19,34 @@ import team.themoment.readygsm.domain.user.service.SearchUserService;
 import java.util.ArrayList;
 import java.util.List;
 
+@Tag(name = "User", description = "사용자 정보 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/user")
+@RequestMapping("/api/v1/users")
 public class UserController {
 
     private final FindUserService findUserService;
     private final SearchUserService searchUserService;
     private final ModifyUserService modifyUserService;
 
+    @Operation(summary = "사용자 정보 조회", description = "사용자의 ID로 사용자 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content())
+    })
     @GetMapping("/{userId}")
     public ResponseEntity<GetUserResDto> getUser(@PathVariable(value = "userId") Long userId) {
         return ResponseEntity.status(HttpStatus.OK).body(findUserService.execute(userId));
     }
 
+    @Operation(summary = "현재 사용자 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
     @GetMapping("/me")
     public ResponseEntity<GetUserResDto> getCurrentUser() {
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(new GetUserResDto(
                 1L, "Test User", "s00000@gsm.hs.kr", UserRole.USER, new ArrayList<>()));
     }
 
+    @Operation(summary = "사용자 검색", description = "이름, 이메일, 역할로 사용자를 검색합니다.")
     @GetMapping("/search")
     public ResponseEntity<List<GetUserResDto>> searchUsers(
             @RequestParam(value = "name", required = false) String name,
@@ -46,6 +59,12 @@ public class UserController {
                 .body(searchUserService.execute(name, email, role, page, limit));
     }
 
+    @Operation(summary = "사용자 정보 수정", description = "사용자의 ID로 사용자 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 정보 수정 성공"),
+            @ApiResponse(responseCode = "403", description = "사용자 권한이 부족함", content = @Content()),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content())
+    })
     @PatchMapping("/{userId}")
     public ResponseEntity<PatchUserResDto> updateUser(
             @PathVariable(value = "userId") Long userId,

--- a/src/main/java/team/themoment/readygsm/global/config/SwaggerConfig.java
+++ b/src/main/java/team/themoment/readygsm/global/config/SwaggerConfig.java
@@ -24,7 +24,7 @@ public class SwaggerConfig {
     public GroupedOpenApi api(OperationCustomizer operationCustomizer) {
         return GroupedOpenApi.builder()
                 .group("Ready, GSM API")
-                .pathsToMatch("/users/**", "/auth/**", "/reservation/**", "/activity/**")
+                .pathsToMatch("/api/v1/users/**", "/api/v1/auth/**", "/api/v1/reservation/**", "/api/v1/activity/**")
                 .addOperationCustomizer(operationCustomizer)
                 .build();
     }


### PR DESCRIPTION
## 개요

> ``UserController``에 Swagger 명세를 추가하였으며 Swagger 라이브러리와 Spring 버전의 차이로 인하여 발생하던 500 Fetch Error를 수정하였습니다.

## 본문

> 사용자 도메인 모델의 ``UserController``에 Swagger를 이용한 API 명세를 위해 어노테이션을 추가 및 작성하였고 Springboot와 OpenAPI Swagger 라이브러리의 버전 충돌 문제로 Swagger 명세서 페이지 조회 시 500 에러와 함께 렌더링이 되지 않던 문제를 라이브러리 버전을 ``2.2.0`` -> ``2.8.9``로 수정하며 해결하였습니다.실제 API 명세와 다르게 설정 되어 있던 Swagger 경로 설정 역시 올바르게 설정하였습니다.