### PR TITLE
[global] Swagger 어노테이션 추가

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
@@ -44,7 +44,7 @@ public class ActivityController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
             @ApiResponse(responseCode = "403", description = "권한 없음")
     })
-    @PostMapping("/create")
+    @PostMapping
     public ActivityResDto createActivity(@RequestBody ActivityReqDto req) {
         return null;
     }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
@@ -57,7 +57,7 @@ public class ActivityController {
             @ApiResponse(responseCode = "403", description = "권한 없음"),
             @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없음")
     })
-    @PatchMapping("/edit/{id}")
+    @PatchMapping("/{id}")
     public ActivityResDto editActivity(@PathVariable Long id, @RequestBody ActivityReqDto req) {
         return null;
     }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.*;
 import team.themoment.readygsmserver.domain.activity.dto.request.ActivityReqDto;
 import team.themoment.readygsmserver.domain.activity.dto.response.ActivityResDto;
 
+import java.util.List;
+
 @RestController
 @Tag(name = "Activity", description = "활동 API")
 @RequestMapping("/api/v1/activity")
@@ -20,7 +22,7 @@ public class ActivityController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
     @GetMapping
-    public ActivityResDto queryAllActivities() {
+    public List<ActivityResDto> queryAllActivities() {
         return null;
     }
 

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
@@ -1,0 +1,73 @@
+package team.themoment.readygsmserver.domain.activity.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import team.themoment.readygsmserver.domain.activity.dto.request.ActivityReqDto;
+import team.themoment.readygsmserver.domain.activity.dto.response.ActivityResDto;
+
+@RestController
+@Tag(name = "Activity", description = "활동 API")
+@RequestMapping("/api/v1/activity")
+public class ActivityController {
+
+    @Operation(summary = "전체 활동 조회", description = "서비스에 등록되어 있는 모든 활동 목록과 각 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @GetMapping
+    public ActivityResDto queryAllActivities() {
+        return null;
+    }
+
+    @Operation(summary = "활동 단일 조회", description = "활동 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없음")
+    })
+    @GetMapping("/{id}")
+    public ActivityResDto queryActivity(@PathVariable Long id) {
+        return null;
+    }
+
+    @Operation(summary = "활동 생성", description = "활동을 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "권한 없음")
+    })
+    @PostMapping("/create")
+    public ActivityResDto createActivity(@RequestBody ActivityReqDto req) {
+        return null;
+    }
+
+    @Operation(summary = "활동 수정", description = "활동 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없음")
+    })
+    @PatchMapping("/edit/{id}")
+    public ActivityResDto editActivity(@PathVariable Long id, @RequestBody ActivityReqDto req) {
+        return null;
+    }
+
+    @Operation(summary = "활동 삭제", description = "활동을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없음")
+    })
+    @DeleteMapping("/delete/{id}")
+    public void deleteActivity(@PathVariable Long id) {
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
@@ -69,7 +69,7 @@ public class ActivityController {
             @ApiResponse(responseCode = "403", description = "권한 없음"),
             @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없음")
     })
-    @DeleteMapping("/delete/{id}")
+    @DeleteMapping("/{id}")
     public void deleteActivity(@PathVariable Long id) {
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/dto/request/ActivityReqDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/dto/request/ActivityReqDto.java
@@ -1,0 +1,14 @@
+package team.themoment.readygsmserver.domain.activity.dto.request;
+
+import java.time.LocalDateTime;
+
+public record ActivityReqDto(
+        String name,
+        String place,
+        String description,
+        Integer maxApplicant,
+        LocalDateTime activityDate,
+        LocalDateTime start,
+        LocalDateTime end
+) {
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/dto/response/ActivityResDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/dto/response/ActivityResDto.java
@@ -1,0 +1,15 @@
+package team.themoment.readygsmserver.domain.activity.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ActivityResDto(
+        Long id,
+        String name,
+        String place,
+        String description,
+        Integer maxApplicant,
+        LocalDateTime activityDate,
+        LocalDateTime start,
+        LocalDateTime end
+) {
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
@@ -1,0 +1,75 @@
+package team.themoment.readygsmserver.domain.application.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import team.themoment.readygsmserver.domain.application.dto.request.ApplicationReqDto;
+import team.themoment.readygsmserver.domain.application.dto.response.ApplicationResDto;
+import team.themoment.readygsmserver.domain.user.dto.response.UserResDto;
+
+import java.util.List;
+
+@RestController
+@Tag(name = "Application", description = "활동 신청 API")
+@RequestMapping("/api/v1/application")
+public class ApplicationController {
+
+    @Operation(summary = "활동 신청", description = "활동을 신청합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "신청 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 신청한 활동")
+    })
+    @PostMapping("/apply")
+    public ApplicationResDto applyActivity(@RequestParam Long activityId, @RequestBody ApplicationReqDto req) {
+        return null;
+    }
+
+    @Operation(summary = "활동 신청 취소", description = "신청된 활동을 신청 취소합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "취소 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "신청 내역을 찾을 수 없음")
+    })
+    @DeleteMapping("/cancel")
+    public void cancelApplication(@RequestParam Long activityId) {
+    }
+
+    @Operation(summary = "신청한 학생 조회", description = "활동을 신청한 학생 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "권한 없음")
+    })
+    @GetMapping("/admin/applications")
+    public List<UserResDto> queryStudents(@RequestParam Long activityId) {
+        return null;
+    }
+
+    @Operation(summary = "특정 학생 활동 신청 취소", description = "id에 해당하는 학생의 활동 신청을 취소합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "취소 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "신청 내역을 찾을 수 없음")
+    })
+    @DeleteMapping("/admin/cancel/{id}")
+    public void deleteApplication(@PathVariable Long id) {
+    }
+
+    @Operation(summary = "활동 신청자 엑셀 출력", description = "활동을 신청한 학생 목록을 엑셀로 출력합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "출력 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "권한 없음")
+    })
+    @GetMapping("/admin/excel")
+    public MultipartFile queryApplication(@RequestParam Long activityId) {
+        return null;
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/application/dto/request/ApplicationReqDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/dto/request/ApplicationReqDto.java
@@ -1,0 +1,12 @@
+package team.themoment.readygsmserver.domain.application.dto.request;
+
+public record ApplicationReqDto(
+        String name,
+        Integer grade,
+        Integer classNumber,
+        Integer number,
+        String schoolName,
+        String phoneNumber,
+        String familyPhoneNumber
+) {
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/application/dto/response/ApplicationResDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/dto/response/ApplicationResDto.java
@@ -1,0 +1,17 @@
+package team.themoment.readygsmserver.domain.application.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ApplicationResDto(
+        Long id,
+        Long activityId,
+        Long userId,
+        String name,
+        Integer grade,
+        Integer classNumber,
+        Integer number,
+        String schoolName,
+        String phoneNumber,
+        String familyPhoneNumber
+) {
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
@@ -1,0 +1,33 @@
+package team.themoment.readygsmserver.domain.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "Auth", description = "인증 API")
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    @Operation(summary = "구글 로그인", description = "Google OAuth2 로그인 페이지로 리다이렉트합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "302", description = "Google 로그인 페이지로 리다이렉트")
+    })
+    @GetMapping("/login")
+    public void login() {
+    }
+
+    @Operation(summary = "구글 로그인 콜백", description = "Google OAuth2 인가 코드를 처리하고 JWT를 발급합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공 및 JWT 발급"),
+            @ApiResponse(responseCode = "400", description = "잘못된 인가 코드"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/callback")
+    public void callback() {
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/user/dto/response/UserResDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/dto/response/UserResDto.java
@@ -1,0 +1,8 @@
+package team.themoment.readygsmserver.domain.user.dto.response;
+
+public record UserResDto(
+        Long id,
+        String email,
+        String role
+) {
+}


### PR DESCRIPTION
## 개요
Swagger 화면을 위해 도메인별 Swagger 어노테이션을 추가하였습니다.
## API 목록
### Auth
| Method | Path | 설명 |
|--------|------|------|
| GET | `/api/v1/auth/login` | Google OAuth2 로그인 페이지로 리다이렉트 |
| GET | `/api/v1/auth/callback` | OAuth2 인가 코드 처리 및 JWT 발급 |

---

### Activity
| Method | Path | 설명 |
|--------|------|------|
| GET | `/api/v1/activity` | 전체 활동 목록 조회 |
| GET | `/api/v1/activity/{id}` | 활동 단일 조회 |
| POST | `/api/v1/activity/create` | 활동 생성 |
| PATCH | `/api/v1/activity/edit/{id}` | 활동 수정 |
| DELETE | `/api/v1/activity/delete/{id}` | 활동 삭제 |

---

### Application
| Method | Path | Query Param | 설명 |
|--------|------|-------------|------|
| POST | `/api/v1/application/apply` | `activityId` | 활동 신청 |
| DELETE | `/api/v1/application/cancel` | `activityId` | 활동 신청 취소 |
| GET | `/api/v1/application/admin/applications` | `activityId` | 신청한 학생 목록 조회 (관리자) |
| DELETE | `/api/v1/application/admin/cancel/{id}` | | 특정 학생 신청 취소 (관리자) |
| GET | `/api/v1/application/admin/excel` | `activityId` | 신청자 엑셀 출력 (관리자) |
