### PR TITLE
[auth] Redis 기반 세션 저장 방식 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     /* Spring Boot Starters */
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,9 +13,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 import team.themoment.readygsmserver.domain.auth.dto.request.OAuthCodeRequest;
 import team.themoment.readygsmserver.domain.auth.service.OAuthAuthenticationService;
 import team.themoment.readygsmserver.global.config.GoogleOAuthProperties;
+import team.themoment.readygsmserver.global.security.oauth2.OAuth2Properties;
 
 import java.io.IOException;
-import java.util.UUID;
 
 @RestController
 @Tag(name = "Auth", description = "인증 API")
@@ -26,14 +25,14 @@ public class AuthController {
 
     private final OAuthAuthenticationService oAuthAuthenticationService;
     private final GoogleOAuthProperties googleOAuthProperties;
+    private final OAuth2Properties oauth2Properties;
 
     @Operation(summary = "Google OAuth 로그인 페이지로 이동", description = "Google 로그인 페이지로 리다이렉트합니다.")
     @GetMapping("/google/redirect")
-    public void redirectToGoogle(HttpServletResponse response, HttpSession session) throws IOException {
-        String state = UUID.randomUUID().toString();
-        session.setAttribute(OAuthAuthenticationService.OAUTH2_STATE_SESSION_KEY, state);
+    public void redirectToGoogle(HttpServletResponse response) throws IOException {
+        String state = oAuthAuthenticationService.generateState();
 
-        String url = UriComponentsBuilder.fromHttpUrl("https://accounts.google.com/o/oauth2/v2/auth")
+        String url = UriComponentsBuilder.fromUriString("https://accounts.google.com/o/oauth2/v2/auth")
                 .queryParam("client_id", googleOAuthProperties.clientId())
                 .queryParam("redirect_uri", googleOAuthProperties.redirectUri())
                 .queryParam("response_type", "code")
@@ -43,7 +42,7 @@ public class AuthController {
         response.sendRedirect(url);
     }
 
-    @Operation(summary = "OAuth 로그인", description = "OAuth Provider로부터 받은 Authorization Code로 로그인합니다.")
+    @Operation(summary = "OAuth 로그인 (SPA용)", description = "프론트엔드에서 Authorization Code와 state를 전달해 로그인합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "인증 완료"),
             @ApiResponse(responseCode = "400", description = "잘못된 인가 코드 또는 state"),
@@ -56,5 +55,17 @@ public class AuthController {
             HttpServletRequest httpRequest) {
         oAuthAuthenticationService.execute(provider, request.code(), request.state(), httpRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "OAuth 콜백 (직접 리다이렉트용)", description = "Google이 직접 백엔드로 리다이렉트할 때 Authorization Code를 처리합니다.")
+    @GetMapping("/{provider}")
+    public void oauthCallback(
+            @PathVariable String provider,
+            @RequestParam String code,
+            @RequestParam String state,
+            HttpServletRequest httpRequest,
+            HttpServletResponse response) throws IOException {
+        oAuthAuthenticationService.execute(provider, code, state, httpRequest);
+        response.sendRedirect(oauth2Properties.successRedirectUrl());
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/auth/service/OAuthAuthenticationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/service/OAuthAuthenticationService.java
@@ -78,10 +78,11 @@ public class OAuthAuthenticationService {
         context.setAuthentication(authentication);
         SecurityContextHolder.setContext(context);
 
-        HttpSession session = request.getSession(false);
-        if (session == null) {
-            session = request.getSession(true);
+        HttpSession oldSession = request.getSession(false);
+        if (oldSession != null) {
+            oldSession.invalidate();
         }
+        HttpSession session = request.getSession(true);
         session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
     }
 

--- a/src/main/java/team/themoment/readygsmserver/domain/auth/service/OAuthAuthenticationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/service/OAuthAuthenticationService.java
@@ -3,6 +3,7 @@ package team.themoment.readygsmserver.domain.auth.service;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -18,22 +19,31 @@ import team.themoment.readygsmserver.domain.user.repository.UserRepository;
 import team.themoment.readygsmserver.global.security.oauth2.OAuthProviderFactory;
 import team.themoment.readygsmserver.global.security.oauth2.provider.OAuthProvider;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class OAuthAuthenticationService {
 
-    static final String OAUTH2_STATE_SESSION_KEY = "oauth2_state";
-    private static final int SESSION_TIMEOUT_SECONDS = 3 * 60 * 60;
+    private static final String OAUTH2_STATE_REDIS_PREFIX = "oauth2:state:";
+    private static final Duration OAUTH2_STATE_TTL = Duration.ofMinutes(5);
 
     private final OAuthProviderFactory oAuthProviderFactory;
     private final UserRepository userRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    public String generateState() {
+        String state = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(OAUTH2_STATE_REDIS_PREFIX + state, "1", OAUTH2_STATE_TTL);
+        return state;
+    }
 
     public void execute(String providerName, String code, String state, HttpServletRequest request) {
-        validateState(state, request);
+        validateState(state);
 
         OAuthProvider provider = oAuthProviderFactory.getProvider(providerName);
         UserAuthInfo userAuthInfo = provider.getUserAuthInfo(code);
@@ -68,22 +78,18 @@ public class OAuthAuthenticationService {
         context.setAuthentication(authentication);
         SecurityContextHolder.setContext(context);
 
-        // 세션 고정 공격 방지: 기존 세션 무효화 후 새 세션 발급
-        request.getSession(false).invalidate();
-        HttpSession newSession = request.getSession(true);
-        newSession.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
-        newSession.setMaxInactiveInterval(SESSION_TIMEOUT_SECONDS);
-    }
-
-    private void validateState(String state, HttpServletRequest request) {
         HttpSession session = request.getSession(false);
         if (session == null) {
-            throw new IllegalStateException("OAuth2 인증 세션이 존재하지 않습니다.");
+            session = request.getSession(true);
         }
-        String savedState = (String) session.getAttribute(OAUTH2_STATE_SESSION_KEY);
-        if (savedState == null || !savedState.equals(state)) {
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+    }
+
+    private void validateState(String state) {
+        String key = OAUTH2_STATE_REDIS_PREFIX + state;
+        Boolean deleted = redisTemplate.delete(key);
+        if (deleted == null || !deleted) {
             throw new IllegalArgumentException("유효하지 않은 state 값입니다. CSRF 공격이 의심됩니다.");
         }
-        session.removeAttribute(OAUTH2_STATE_SESSION_KEY);
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
@@ -7,9 +7,15 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.session.web.http.CookieSerializer;
+import org.springframework.session.web.http.DefaultCookieSerializer;
 
 @Configuration
 @EnableWebSecurity
+@EnableRedisHttpSession
 public class SecurityConfig {
 
     private static final String[] PUBLIC_PATHS = {
@@ -25,13 +31,33 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .sessionManagement(session ->
-                        session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                        .sessionFixation().none()
+                )
+                .securityContext(secContext -> secContext
+                        .securityContextRepository(securityContextRepository())
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PUBLIC_PATHS).permitAll()
                         .anyRequest().authenticated()
                 );
 
         return http.build();
+    }
+
+    @Bean
+    public SecurityContextRepository securityContextRepository() {
+        return new HttpSessionSecurityContextRepository();
+    }
+
+    @Bean
+    public CookieSerializer cookieSerializer() {
+        DefaultCookieSerializer serializer = new DefaultCookieSerializer();
+        serializer.setCookieName("SESSION");
+        serializer.setUseHttpOnlyCookie(true);
+        serializer.setSameSite("Lax");
+        serializer.setCookiePath("/");
+        return serializer;
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
@@ -33,7 +33,6 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
-                        .sessionFixation().none()
                 )
                 .securityContext(secContext -> secContext
                         .securityContextRepository(securityContextRepository())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,7 +60,7 @@ sdk:
     not-logging-urls:
       - "/v3/api-docs/**"
       - "/swagger-ui/**"
-      - "/api/v1/auth/**"
+      - "/api/v1/auth/callback"
 
   response:
     enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,11 @@ spring:
       host: localhost
       port: 6379
 
+  session:
+    redis:
+      flush-mode: immediate
+      save-mode: on-set-attribute
+
   security:
     oauth2:
       client:
@@ -38,8 +43,6 @@ server:
   servlet:
     session:
       timeout: 3h
-      cookie:
-        same-site: strict
 
 google:
   oauth:
@@ -57,6 +60,7 @@ sdk:
     not-logging-urls:
       - "/v3/api-docs/**"
       - "/swagger-ui/**"
+      - "/api/v1/auth/**"
 
   response:
     enabled: true


### PR DESCRIPTION
## 개요

Spring Session + Redis를 도입하여 세션을 Redis에 저장하도록 전환합니다.

## 변경 사항

- `spring-session-data-redis` 의존성 추가
- `@EnableRedisHttpSession` 적용으로 세션 저장소를 Redis로 전환
- `CookieSerializer` 빈 등록 — 쿠키 이름 `SESSION`, `HttpOnly`, `SameSite=Lax` 설정
- `application.yml`에 세션 flush/save 모드 설정 추가 (`immediate` / `on-set-attribute`)
- OAuth state 검증을 `HttpSession` 기반에서 Redis TTL(5분) 기반으로 교체
- `SecurityContextRepository` 빈 등록 및 `securityContext()` 설정 추가
- `OAuthAuthenticationService` — `session.setAttribute()` 직접 저장 방식으로 변경

## 테스트 방법

- [ ] Google OAuth 로그인 흐름 정상 동작 확인
- [ ] 로그인 후 인증이 필요한 엔드포인트 접근 가능 확인
- [ ] Redis에 `SESSION:*` 키가 생성되는지 확인