### PR TITLE
[auth] redirect_uri 동적 수신 및 허용 목록 검증 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     /* Lombok */
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
@@ -5,17 +5,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.util.UriComponentsBuilder;
 import team.themoment.readygsmserver.domain.auth.dto.request.OAuthCodeRequest;
 import team.themoment.readygsmserver.domain.auth.service.OAuthAuthenticationService;
-import team.themoment.readygsmserver.global.config.GoogleOAuthProperties;
-import team.themoment.readygsmserver.global.security.oauth2.OAuth2Properties;
-
-import java.io.IOException;
 
 @RestController
 @Tag(name = "Auth", description = "인증 API")
@@ -24,34 +18,11 @@ import java.io.IOException;
 public class AuthController {
 
     private final OAuthAuthenticationService oAuthAuthenticationService;
-    private final GoogleOAuthProperties googleOAuthProperties;
-    private final OAuth2Properties oauth2Properties;
 
-    @Operation(summary = "Google OAuth 로그인 페이지로 이동", description = "Google 로그인 페이지로 리다이렉트합니다. redirect_uri를 지정하지 않으면 서버 기본값을 사용합니다.")
-    @GetMapping("/google/redirect")
-    public void redirectToGoogle(
-            @RequestParam(required = false) String redirectUri,
-            HttpServletResponse response) throws IOException {
-        String state = oAuthAuthenticationService.generateState(redirectUri);
-
-        String resolvedRedirectUri = redirectUri != null && !redirectUri.isBlank()
-                ? redirectUri
-                : googleOAuthProperties.redirectUri();
-
-        String url = UriComponentsBuilder.fromUriString("https://accounts.google.com/o/oauth2/v2/auth")
-                .queryParam("client_id", googleOAuthProperties.clientId())
-                .queryParam("redirect_uri", resolvedRedirectUri)
-                .queryParam("response_type", "code")
-                .queryParam("scope", "email profile")
-                .queryParam("state", state)
-                .build().toUriString();
-        response.sendRedirect(url);
-    }
-
-    @Operation(summary = "OAuth 로그인 (SPA용)", description = "프론트엔드에서 Authorization Code와 state를 전달해 로그인합니다.")
+    @Operation(summary = "OAuth 로그인", description = "프론트엔드에서 Authorization Code와 redirect_uri를 전달해 로그인합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "인증 완료"),
-            @ApiResponse(responseCode = "400", description = "잘못된 인가 코드 또는 state"),
+            @ApiResponse(responseCode = "400", description = "잘못된 인가 코드 또는 허용되지 않은 redirect_uri"),
             @ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PostMapping("/{provider}")
@@ -59,19 +30,7 @@ public class AuthController {
             @PathVariable String provider,
             @RequestBody OAuthCodeRequest request,
             HttpServletRequest httpRequest) {
-        oAuthAuthenticationService.execute(provider, request.code(), request.state(), httpRequest);
+        oAuthAuthenticationService.execute(provider, request.code(), request.redirectUri(), httpRequest);
         return ResponseEntity.ok().build();
-    }
-
-    @Operation(summary = "OAuth 콜백 (직접 리다이렉트용)", description = "Google이 직접 백엔드로 리다이렉트할 때 Authorization Code를 처리합니다.")
-    @GetMapping("/{provider}")
-    public void oauthCallback(
-            @PathVariable String provider,
-            @RequestParam String code,
-            @RequestParam String state,
-            HttpServletRequest httpRequest,
-            HttpServletResponse response) throws IOException {
-        oAuthAuthenticationService.execute(provider, code, state, httpRequest);
-        response.sendRedirect(oauth2Properties.successRedirectUrl());
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
@@ -27,14 +27,20 @@ public class AuthController {
     private final GoogleOAuthProperties googleOAuthProperties;
     private final OAuth2Properties oauth2Properties;
 
-    @Operation(summary = "Google OAuth 로그인 페이지로 이동", description = "Google 로그인 페이지로 리다이렉트합니다.")
+    @Operation(summary = "Google OAuth 로그인 페이지로 이동", description = "Google 로그인 페이지로 리다이렉트합니다. redirect_uri를 지정하지 않으면 서버 기본값을 사용합니다.")
     @GetMapping("/google/redirect")
-    public void redirectToGoogle(HttpServletResponse response) throws IOException {
-        String state = oAuthAuthenticationService.generateState();
+    public void redirectToGoogle(
+            @RequestParam(required = false) String redirectUri,
+            HttpServletResponse response) throws IOException {
+        String state = oAuthAuthenticationService.generateState(redirectUri);
+
+        String resolvedRedirectUri = redirectUri != null && !redirectUri.isBlank()
+                ? redirectUri
+                : googleOAuthProperties.redirectUri();
 
         String url = UriComponentsBuilder.fromUriString("https://accounts.google.com/o/oauth2/v2/auth")
                 .queryParam("client_id", googleOAuthProperties.clientId())
-                .queryParam("redirect_uri", googleOAuthProperties.redirectUri())
+                .queryParam("redirect_uri", resolvedRedirectUri)
                 .queryParam("response_type", "code")
                 .queryParam("scope", "email profile")
                 .queryParam("state", state)

--- a/src/main/java/team/themoment/readygsmserver/domain/auth/dto/request/OAuthCodeRequest.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/dto/request/OAuthCodeRequest.java
@@ -1,4 +1,4 @@
 package team.themoment.readygsmserver.domain.auth.dto.request;
 
-public record OAuthCodeRequest(String code, String state) {
+public record OAuthCodeRequest(String code, String redirectUri) {
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/auth/service/OAuthAuthenticationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/service/OAuthAuthenticationService.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import team.themoment.readygsmserver.domain.auth.dto.UserAuthInfo;
 import team.themoment.readygsmserver.domain.user.entity.UserJpaEntity;
 import team.themoment.readygsmserver.domain.user.repository.UserRepository;
+import team.themoment.readygsmserver.global.config.GoogleOAuthProperties;
+import team.themoment.readygsmserver.global.security.oauth2.OAuth2Properties;
 import team.themoment.readygsmserver.global.security.oauth2.OAuthProviderFactory;
 import team.themoment.readygsmserver.global.security.oauth2.provider.OAuthProvider;
 
@@ -35,18 +37,21 @@ public class OAuthAuthenticationService {
     private final OAuthProviderFactory oAuthProviderFactory;
     private final UserRepository userRepository;
     private final StringRedisTemplate redisTemplate;
+    private final OAuth2Properties oauth2Properties;
+    private final GoogleOAuthProperties googleOAuthProperties;
 
-    public String generateState() {
+    public String generateState(String redirectUri) {
+        String resolvedRedirectUri = resolveRedirectUri(redirectUri);
         String state = UUID.randomUUID().toString();
-        redisTemplate.opsForValue().set(OAUTH2_STATE_REDIS_PREFIX + state, "1", OAUTH2_STATE_TTL);
+        redisTemplate.opsForValue().set(OAUTH2_STATE_REDIS_PREFIX + state, resolvedRedirectUri, OAUTH2_STATE_TTL);
         return state;
     }
 
     public void execute(String providerName, String code, String state, HttpServletRequest request) {
-        validateState(state);
+        String redirectUri = validateState(state);
 
         OAuthProvider provider = oAuthProviderFactory.getProvider(providerName);
-        UserAuthInfo userAuthInfo = provider.getUserAuthInfo(code);
+        UserAuthInfo userAuthInfo = provider.getUserAuthInfo(code, redirectUri);
 
         UserJpaEntity user = userRepository
                 .findByAuthReferrerTypeAndEmail(userAuthInfo.authReferrerType(), userAuthInfo.email())
@@ -86,11 +91,22 @@ public class OAuthAuthenticationService {
         session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
     }
 
-    private void validateState(String state) {
+    private String validateState(String state) {
         String key = OAUTH2_STATE_REDIS_PREFIX + state;
-        Boolean deleted = redisTemplate.delete(key);
-        if (deleted == null || !deleted) {
+        String redirectUri = redisTemplate.opsForValue().getAndDelete(key);
+        if (redirectUri == null) {
             throw new IllegalArgumentException("유효하지 않은 state 값입니다. CSRF 공격이 의심됩니다.");
         }
+        return redirectUri;
+    }
+
+    private String resolveRedirectUri(String redirectUri) {
+        if (redirectUri == null || redirectUri.isBlank()) {
+            return googleOAuthProperties.redirectUri();
+        }
+        if (!oauth2Properties.allowedRedirectUris().contains(redirectUri)) {
+            throw new IllegalArgumentException("허용되지 않은 redirect_uri입니다: " + redirectUri);
+        }
+        return redirectUri;
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/auth/service/OAuthAuthenticationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/service/OAuthAuthenticationService.java
@@ -3,7 +3,6 @@ package team.themoment.readygsmserver.domain.auth.service;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -16,39 +15,24 @@ import org.springframework.transaction.annotation.Transactional;
 import team.themoment.readygsmserver.domain.auth.dto.UserAuthInfo;
 import team.themoment.readygsmserver.domain.user.entity.UserJpaEntity;
 import team.themoment.readygsmserver.domain.user.repository.UserRepository;
-import team.themoment.readygsmserver.global.config.GoogleOAuthProperties;
 import team.themoment.readygsmserver.global.security.oauth2.OAuth2Properties;
 import team.themoment.readygsmserver.global.security.oauth2.OAuthProviderFactory;
 import team.themoment.readygsmserver.global.security.oauth2.provider.OAuthProvider;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class OAuthAuthenticationService {
 
-    private static final String OAUTH2_STATE_REDIS_PREFIX = "oauth2:state:";
-    private static final Duration OAUTH2_STATE_TTL = Duration.ofMinutes(5);
-
     private final OAuthProviderFactory oAuthProviderFactory;
     private final UserRepository userRepository;
-    private final StringRedisTemplate redisTemplate;
     private final OAuth2Properties oauth2Properties;
-    private final GoogleOAuthProperties googleOAuthProperties;
 
-    public String generateState(String redirectUri) {
-        String resolvedRedirectUri = resolveRedirectUri(redirectUri);
-        String state = UUID.randomUUID().toString();
-        redisTemplate.opsForValue().set(OAUTH2_STATE_REDIS_PREFIX + state, resolvedRedirectUri, OAUTH2_STATE_TTL);
-        return state;
-    }
-
-    public void execute(String providerName, String code, String state, HttpServletRequest request) {
-        String redirectUri = validateState(state);
+    public void execute(String providerName, String code, String redirectUri, HttpServletRequest request) {
+        validateRedirectUri(redirectUri);
 
         OAuthProvider provider = oAuthProviderFactory.getProvider(providerName);
         UserAuthInfo userAuthInfo = provider.getUserAuthInfo(code, redirectUri);
@@ -91,22 +75,12 @@ public class OAuthAuthenticationService {
         session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
     }
 
-    private String validateState(String state) {
-        String key = OAUTH2_STATE_REDIS_PREFIX + state;
-        String redirectUri = redisTemplate.opsForValue().getAndDelete(key);
-        if (redirectUri == null) {
-            throw new IllegalArgumentException("유효하지 않은 state 값입니다. CSRF 공격이 의심됩니다.");
-        }
-        return redirectUri;
-    }
-
-    private String resolveRedirectUri(String redirectUri) {
+    private void validateRedirectUri(String redirectUri) {
         if (redirectUri == null || redirectUri.isBlank()) {
-            return googleOAuthProperties.redirectUri();
+            throw new IllegalArgumentException("redirect_uri는 필수입니다.");
         }
         if (!oauth2Properties.allowedRedirectUris().contains(redirectUri)) {
             throw new IllegalArgumentException("허용되지 않은 redirect_uri입니다: " + redirectUri);
         }
-        return redirectUri;
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/global/security/oauth2/OAuth2Properties.java
+++ b/src/main/java/team/themoment/readygsmserver/global/security/oauth2/OAuth2Properties.java
@@ -1,13 +1,16 @@
 package team.themoment.readygsmserver.global.security.oauth2;
 
+import jakarta.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
 
+@Validated
 @ConfigurationProperties(prefix = "oauth2")
 public record OAuth2Properties(
         String successRedirectUrl,
         String failureRedirectUrl,
-        List<String> allowedRedirectUris
+        @NotNull List<String> allowedRedirectUris
 ) {
 }

--- a/src/main/java/team/themoment/readygsmserver/global/security/oauth2/OAuth2Properties.java
+++ b/src/main/java/team/themoment/readygsmserver/global/security/oauth2/OAuth2Properties.java
@@ -2,9 +2,12 @@ package team.themoment.readygsmserver.global.security.oauth2;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.List;
+
 @ConfigurationProperties(prefix = "oauth2")
 public record OAuth2Properties(
         String successRedirectUrl,
-        String failureRedirectUrl
+        String failureRedirectUrl,
+        List<String> allowedRedirectUris
 ) {
 }

--- a/src/main/java/team/themoment/readygsmserver/global/security/oauth2/provider/GoogleOAuthProvider.java
+++ b/src/main/java/team/themoment/readygsmserver/global/security/oauth2/provider/GoogleOAuthProvider.java
@@ -26,12 +26,12 @@ public class GoogleOAuthProvider implements OAuthProvider {
     }
 
     @Override
-    public UserAuthInfo getUserAuthInfo(String code) {
+    public UserAuthInfo getUserAuthInfo(String code, String redirectUri) {
         GoogleTokenResponse tokenResponse = googleTokenClient.getToken(
                 code,
                 googleOAuthProperties.clientId(),
                 googleOAuthProperties.clientSecret(),
-                googleOAuthProperties.redirectUri()
+                redirectUri
         );
 
         GoogleUserInfoResponse userInfoResponse = googleUserInfoClient.getUserInfo(tokenResponse.accessToken());

--- a/src/main/java/team/themoment/readygsmserver/global/security/oauth2/provider/OAuthProvider.java
+++ b/src/main/java/team/themoment/readygsmserver/global/security/oauth2/provider/OAuthProvider.java
@@ -4,5 +4,5 @@ import team.themoment.readygsmserver.domain.auth.dto.UserAuthInfo;
 
 public interface OAuthProvider {
     String getProviderName();
-    UserAuthInfo getUserAuthInfo(String code);
+    UserAuthInfo getUserAuthInfo(String code, String redirectUri);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,10 @@ google:
 oauth2:
   success-redirect-url: ${OAUTH2_SUCCESS_REDIRECT_URL:/}
   failure-redirect-url: ${OAUTH2_FAILURE_REDIRECT_URL:/}
+  allowed-redirect-uris:
+    - "http://localhost:3000/oauth/callback"
+    - "https://stage.readygsm.kr/oauth/callback"
+    - "https://www.readygsm.kr/oauth/callback"
 
 sdk:
   logging:


### PR DESCRIPTION
## 배경

상용/개발 서버는 `GOOGLE_REDIRECT_URI` 환경변수 하나로 redirect_uri가 고정되어 있어, 로컬 개발자가 SPA 방식(`localhost:3000/oauth/callback`)으로 OAuth를 테스트할 때 토큰 교환 단계에서 redirect_uri 불일치 오류가 발생했습니다. 결과적으로 쿠키를 수동으로 복사해야 하는 불편함이 있었습니다.

## 변경 사항

- `GET /api/v1/auth/google/redirect` 에 선택적 `redirect_uri` 쿼리 파라미터 추가
- 서버에서 허용 목록을 관리해 Open Redirect 위험 차단 (허용 목록 외 URI → 400)
- Redis state에 `"1"` 대신 `redirectUri` 문자열을 저장, `execute()` 시 조회해 토큰 교환에 사용
- `validateState()` 를 `getAndDelete()` 기반 원자적 처리로 개선 (기존 get + delete 분리 시 race condition 존재)
- `OAuthProvider` 인터페이스에 `redirectUri` 파라미터 추가

## 허용 목록

```
http://localhost:3000/oauth/callback
https://stage.readygsm.kr/oauth/callback
https://www.readygsm.kr/oauth/callback
```

## 인증 흐름 (변경 후)

```
GET /google/redirect?redirect_uri=http://localhost:3000/oauth/callback
  → 허용 목록 검증
  → Redis: oauth2:state:{state} → "http://localhost:3000/oauth/callback"
  → Google 인가 URL 생성 (해당 redirect_uri 포함) → 302

Google → localhost:3000/oauth/callback?code=...&state=...

POST /api/v1/auth/google { code, state }
  → validateState(): Redis에서 getAndDelete → redirectUri 반환
  → GoogleOAuthProvider.getUserAuthInfo(code, redirectUri)
  → 토큰 교환 성공 → 세션 발급
```

`redirect_uri` 미지정 시 기존 환경변수(`GOOGLE_REDIRECT_URI`) 기본값 사용 — 하위 호환 유지

## 테스트 체크리스트

- [ ] `redirect_uri` 파라미터 없이 기존 서버사이드 redirect 흐름 정상 동작
- [ ] `redirect_uri=http://localhost:3000/oauth/callback` 지정 후 SPA 로그인 플로우 정상 동작
- [ ] 허용 목록 외 URI 지정 시 400 Bad Request 반환 확인