### PR TITLE
[auth] 카카오 OAuth 로그인 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,4 +30,3 @@ The following environment variables are required before running.
 | `GOOGLE_REDIRECT_URI` | Google OAuth2 redirect URI (must match Google Console registration, e.g. `http://localhost:3000/oauth/callback`) |
 | `KAKAO_CLIENT_ID` | Kakao OAuth2 REST API key |
 | `KAKAO_CLIENT_SECRET` | Kakao OAuth2 client secret |
-| `KAKAO_REDIRECT_URI` | Kakao OAuth2 redirect URI (must match Kakao Developers registration) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,6 @@ The following environment variables are required before running.
 | `GOOGLE_CLIENT_ID` | Google OAuth2 client ID |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth2 client secret |
 | `GOOGLE_REDIRECT_URI` | Google OAuth2 redirect URI (must match Google Console registration, e.g. `http://localhost:3000/oauth/callback`) |
+| `KAKAO_CLIENT_ID` | Kakao OAuth2 REST API key |
+| `KAKAO_CLIENT_SECRET` | Kakao OAuth2 client secret |
+| `KAKAO_REDIRECT_URI` | Kakao OAuth2 redirect URI (must match Kakao Developers registration) |

--- a/src/main/java/team/themoment/readygsmserver/domain/user/entity/constant/AuthReferrerType.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/entity/constant/AuthReferrerType.java
@@ -1,5 +1,6 @@
 package team.themoment.readygsmserver.domain.user.entity.constant;
 
 public enum AuthReferrerType {
-    GOOGLE
+    GOOGLE,
+    KAKAO
 }

--- a/src/main/java/team/themoment/readygsmserver/global/config/FeignClientConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/FeignClientConfig.java
@@ -8,6 +8,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import team.themoment.readygsmserver.global.security.oauth2.feign.GoogleTokenClient;
 import team.themoment.readygsmserver.global.security.oauth2.feign.GoogleUserInfoClient;
+import team.themoment.readygsmserver.global.security.oauth2.feign.KakaoTokenClient;
+import team.themoment.readygsmserver.global.security.oauth2.feign.KakaoUserInfoClient;
 
 @Configuration
 public class FeignClientConfig {
@@ -27,5 +29,19 @@ public class FeignClientConfig {
         return Feign.builder()
                 .decoder(new JacksonDecoder(objectMapper))
                 .target(GoogleUserInfoClient.class, "https://www.googleapis.com");
+    }
+
+    @Bean
+    public KakaoTokenClient kakaoTokenClient() {
+        return Feign.builder()
+                .decoder(new JacksonDecoder(objectMapper))
+                .target(KakaoTokenClient.class, "https://kauth.kakao.com");
+    }
+
+    @Bean
+    public KakaoUserInfoClient kakaoUserInfoClient() {
+        return Feign.builder()
+                .decoder(new JacksonDecoder(objectMapper))
+                .target(KakaoUserInfoClient.class, "https://kapi.kakao.com");
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/global/config/KakaoOAuthProperties.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/KakaoOAuthProperties.java
@@ -1,0 +1,7 @@
+package team.themoment.readygsmserver.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("kakao.oauth")
+public record KakaoOAuthProperties(String clientId, String clientSecret, String redirectUri) {
+}

--- a/src/main/java/team/themoment/readygsmserver/global/config/KakaoOAuthProperties.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/KakaoOAuthProperties.java
@@ -3,5 +3,5 @@ package team.themoment.readygsmserver.global.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("kakao.oauth")
-public record KakaoOAuthProperties(String clientId, String clientSecret, String redirectUri) {
+public record KakaoOAuthProperties(String clientId, String clientSecret) {
 }

--- a/src/main/java/team/themoment/readygsmserver/global/security/oauth2/feign/KakaoTokenClient.java
+++ b/src/main/java/team/themoment/readygsmserver/global/security/oauth2/feign/KakaoTokenClient.java
@@ -1,0 +1,20 @@
+package team.themoment.readygsmserver.global.security.oauth2.feign;
+
+import feign.Body;
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import team.themoment.readygsmserver.global.security.oauth2.feign.dto.KakaoTokenResponse;
+
+public interface KakaoTokenClient {
+
+    @RequestLine("POST /oauth/token")
+    @Headers("Content-Type: application/x-www-form-urlencoded")
+    @Body("code={code}&client_id={clientId}&client_secret={clientSecret}&redirect_uri={redirectUri}&grant_type=authorization_code")
+    KakaoTokenResponse getToken(
+            @Param("code") String code,
+            @Param("clientId") String clientId,
+            @Param("clientSecret") String clientSecret,
+            @Param("redirectUri") String redirectUri
+    );
+}

--- a/src/main/java/team/themoment/readygsmserver/global/security/oauth2/feign/KakaoUserInfoClient.java
+++ b/src/main/java/team/themoment/readygsmserver/global/security/oauth2/feign/KakaoUserInfoClient.java
@@ -1,0 +1,13 @@
+package team.themoment.readygsmserver.global.security.oauth2.feign;
+
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import team.themoment.readygsmserver.global.security.oauth2.feign.dto.KakaoUserInfoResponse;
+
+public interface KakaoUserInfoClient {
+
+    @RequestLine("GET /v2/user/me")
+    @Headers("Authorization: Bearer {accessToken}")
+    KakaoUserInfoResponse getUserInfo(@Param("accessToken") String accessToken);
+}

--- a/src/main/java/team/themoment/readygsmserver/global/security/oauth2/feign/dto/KakaoTokenResponse.java
+++ b/src/main/java/team/themoment/readygsmserver/global/security/oauth2/feign/dto/KakaoTokenResponse.java
@@ -1,0 +1,10 @@
+package team.themoment.readygsmserver.global.security.oauth2.feign.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoTokenResponse(
+        @JsonProperty("access_token") String accessToken
+) {
+}

--- a/src/main/java/team/themoment/readygsmserver/global/security/oauth2/feign/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/team/themoment/readygsmserver/global/security/oauth2/feign/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,17 @@
+package team.themoment.readygsmserver.global.security.oauth2.feign.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoUserInfoResponse(
+        Long id,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record KakaoAccount(String email) {}
+
+    public String email() {
+        return kakaoAccount != null ? kakaoAccount.email() : null;
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/global/security/oauth2/provider/KakaoOAuthProvider.java
+++ b/src/main/java/team/themoment/readygsmserver/global/security/oauth2/provider/KakaoOAuthProvider.java
@@ -1,0 +1,41 @@
+package team.themoment.readygsmserver.global.security.oauth2.provider;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import team.themoment.readygsmserver.domain.auth.dto.UserAuthInfo;
+import team.themoment.readygsmserver.domain.user.entity.constant.AuthReferrerType;
+import team.themoment.readygsmserver.global.config.KakaoOAuthProperties;
+import team.themoment.readygsmserver.global.security.oauth2.feign.KakaoTokenClient;
+import team.themoment.readygsmserver.global.security.oauth2.feign.KakaoUserInfoClient;
+import team.themoment.readygsmserver.global.security.oauth2.feign.dto.KakaoTokenResponse;
+import team.themoment.readygsmserver.global.security.oauth2.feign.dto.KakaoUserInfoResponse;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthProvider implements OAuthProvider {
+
+    private static final String PROVIDER_NAME = "kakao";
+
+    private final KakaoTokenClient kakaoTokenClient;
+    private final KakaoUserInfoClient kakaoUserInfoClient;
+    private final KakaoOAuthProperties kakaoOAuthProperties;
+
+    @Override
+    public String getProviderName() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    public UserAuthInfo getUserAuthInfo(String code, String redirectUri) {
+        KakaoTokenResponse tokenResponse = kakaoTokenClient.getToken(
+                code,
+                kakaoOAuthProperties.clientId(),
+                kakaoOAuthProperties.clientSecret(),
+                redirectUri
+        );
+
+        KakaoUserInfoResponse userInfoResponse = kakaoUserInfoClient.getUserInfo(tokenResponse.accessToken());
+
+        return new UserAuthInfo(userInfoResponse.email(), PROVIDER_NAME, AuthReferrerType.KAKAO);
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/global/security/oauth2/provider/KakaoOAuthProvider.java
+++ b/src/main/java/team/themoment/readygsmserver/global/security/oauth2/provider/KakaoOAuthProvider.java
@@ -1,6 +1,7 @@
 package team.themoment.readygsmserver.global.security.oauth2.provider;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import team.themoment.readygsmserver.domain.auth.dto.UserAuthInfo;
 import team.themoment.readygsmserver.domain.user.entity.constant.AuthReferrerType;
@@ -9,6 +10,7 @@ import team.themoment.readygsmserver.global.security.oauth2.feign.KakaoTokenClie
 import team.themoment.readygsmserver.global.security.oauth2.feign.KakaoUserInfoClient;
 import team.themoment.readygsmserver.global.security.oauth2.feign.dto.KakaoTokenResponse;
 import team.themoment.readygsmserver.global.security.oauth2.feign.dto.KakaoUserInfoResponse;
+import team.themoment.sdk.exception.ExpectedException;
 
 @Component
 @RequiredArgsConstructor
@@ -37,7 +39,7 @@ public class KakaoOAuthProvider implements OAuthProvider {
         KakaoUserInfoResponse userInfoResponse = kakaoUserInfoClient.getUserInfo(tokenResponse.accessToken());
 
         if (userInfoResponse.email() == null) {
-            throw new IllegalArgumentException("카카오 계정의 이메일 정보를 불러올 수 없습니다. 필수 동의 항목을 확인해주세요.");
+            throw new ExpectedException("카카오 계정의 이메일 정보를 불러올 수 없습니다. 필수 동의 항목을 확인해주세요.", HttpStatus.BAD_REQUEST);
         }
 
         return new UserAuthInfo(userInfoResponse.email(), PROVIDER_NAME, AuthReferrerType.KAKAO);

--- a/src/main/java/team/themoment/readygsmserver/global/security/oauth2/provider/KakaoOAuthProvider.java
+++ b/src/main/java/team/themoment/readygsmserver/global/security/oauth2/provider/KakaoOAuthProvider.java
@@ -36,6 +36,10 @@ public class KakaoOAuthProvider implements OAuthProvider {
 
         KakaoUserInfoResponse userInfoResponse = kakaoUserInfoClient.getUserInfo(tokenResponse.accessToken());
 
+        if (userInfoResponse.email() == null) {
+            throw new IllegalArgumentException("카카오 계정의 이메일 정보를 불러올 수 없습니다. 필수 동의 항목을 확인해주세요.");
+        }
+
         return new UserAuthInfo(userInfoResponse.email(), PROVIDER_NAME, AuthReferrerType.KAKAO);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,12 @@ google:
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: ${GOOGLE_REDIRECT_URI}
 
+kakao:
+  oauth:
+    client-id: ${KAKAO_CLIENT_ID}
+    client-secret: ${KAKAO_CLIENT_SECRET}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
+
 oauth2:
   success-redirect-url: ${OAUTH2_SUCCESS_REDIRECT_URL:/}
   failure-redirect-url: ${OAUTH2_FAILURE_REDIRECT_URL:/}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,7 +55,6 @@ kakao:
   oauth:
     client-id: ${KAKAO_CLIENT_ID}
     client-secret: ${KAKAO_CLIENT_SECRET}
-    redirect-uri: ${KAKAO_REDIRECT_URI}
 
 oauth2:
   success-redirect-url: ${OAUTH2_SUCCESS_REDIRECT_URL:/}


### PR DESCRIPTION
## 변경 사항

Google OAuth와 동일한 구조로 카카오 OAuth 로그인을 구현하였습니다.
`OAuthProviderFactory`가 provider 이름으로 구현체를 선택하는 기존 확장 구조에 따라, 새로운 파일 추가만으로 카카오 인증을 지원하도록 구성하였습니다.

## 주요 변경 내역

### 신규 파일

| 파일 | 설명 |
|---|---|
| `KakaoOAuthProperties` | `kakao.oauth.*` 환경변수 바인딩 |
| `KakaoTokenClient` | `kauth.kakao.com/oauth/token` Feign 클라이언트 |
| `KakaoUserInfoClient` | `kapi.kakao.com/v2/user/me` Feign 클라이언트 |
| `KakaoTokenResponse` | 토큰 응답 DTO |
| `KakaoUserInfoResponse` | 중첩 구조(`kakao_account.email`) 처리 포함 유저 정보 응답 DTO |
| `KakaoOAuthProvider` | `OAuthProvider` 구현체 (provider name: `"kakao"`) |

### 수정 파일

- `FeignClientConfig` — `KakaoTokenClient`, `KakaoUserInfoClient` 빈 등록하였습니다
- `AuthReferrerType` — `KAKAO` 값 추가하였습니다
- `application.yml` — `kakao.oauth.client-id/client-secret/redirect-uri` 설정 추가하였습니다
- `CLAUDE.md` — 환경변수 목록에 Kakao 항목 추가하였습니다

## 인증 흐름

기존 Google OAuth와 동일한 흐름을 사용하였습니다.

```
POST /api/v1/auth/kakao
  { "code": "...", "redirectUri": "..." }
        ↓
OAuthAuthenticationService
        ↓
OAuthProviderFactory.getProvider("kakao")
        ↓
KakaoTokenClient  →  kauth.kakao.com/oauth/token
        ↓
KakaoUserInfoClient  →  kapi.kakao.com/v2/user/me
        ↓
UserRepository (기존 유저 조회 or 신규 저장)
        ↓
HttpSession(Redis) 저장
```

## 필요한 환경변수

```
KAKAO_CLIENT_ID=<카카오 REST API 키>
KAKAO_CLIENT_SECRET=<카카오 클라이언트 시크릿>
KAKAO_REDIRECT_URI=<Kakao Developers에 등록한 Redirect URI>
```

> Kakao Developers 콘솔에서 **카카오계정 > 이메일 동의를 필수**로 설정하여야 `email` 필드가 응답에 포함됩니다.

## 체크리스트

- [x] 기존 Google OAuth 흐름에 영향 없음
- [x] `OAuthProvider` 인터페이스 규약 준수
- [ ] `KAKAO_CLIENT_ID`, `KAKAO_CLIENT_SECRET`, `KAKAO_REDIRECT_URI` 환경변수 설정
- [ ] `POST /api/v1/auth/kakao` 엔드포인트 동작 확인
- [ ] 기존 `POST /api/v1/auth/google` 정상 동작 유지 확인