### PR TITLE
[application] 활동 신청 도메인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
     /* sdk */
     implementation("com.github.themoment-team:the-sdk:1.5")
+
+    /* Excel */
+    implementation 'org.apache.poi:poi-ooxml:5.5.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/repository/ActivityRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/repository/ActivityRepository.java
@@ -1,0 +1,7 @@
+package team.themoment.readygsmserver.domain.activity.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
+
+public interface ActivityRepository extends JpaRepository<ActivityJpaEntity, Long> {
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/repository/ActivityRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/repository/ActivityRepository.java
@@ -1,7 +1,16 @@
 package team.themoment.readygsmserver.domain.activity.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
 
+import java.util.Optional;
+
 public interface ActivityRepository extends JpaRepository<ActivityJpaEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT a FROM ActivityJpaEntity a WHERE a.id = :id")
+    Optional<ActivityJpaEntity> findByIdWithLock(Long id);
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 import team.themoment.readygsmserver.domain.application.dto.request.ApplicationReqDto;
 import team.themoment.readygsmserver.domain.application.dto.response.ApplicationResDto;
 import team.themoment.readygsmserver.domain.application.service.ApplyActivityService;
@@ -43,7 +44,7 @@ public class ApplicationController {
             @ApiResponse(responseCode = "409", description = "이미 신청한 활동")
     })
     @PostMapping("/apply")
-    public ApplicationResDto applyActivity(@AuthRequest Long userId, @RequestParam Long activityId, @RequestBody ApplicationReqDto req) {
+    public ApplicationResDto applyActivity(@AuthRequest Long userId, @RequestParam Long activityId, @Valid @RequestBody ApplicationReqDto req) {
         return applyActivityService.execute(userId, activityId, req);
     }
 

--- a/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
@@ -4,18 +4,35 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import team.themoment.readygsmserver.domain.application.dto.request.ApplicationReqDto;
 import team.themoment.readygsmserver.domain.application.dto.response.ApplicationResDto;
-import team.themoment.readygsmserver.domain.user.dto.response.UserResDto;
+import team.themoment.readygsmserver.domain.application.service.ApplyActivityService;
+import team.themoment.readygsmserver.domain.application.service.CancelApplicationService;
+import team.themoment.readygsmserver.domain.application.service.DeleteApplicationService;
+import team.themoment.readygsmserver.domain.application.service.ExportApplicationExcelService;
+import team.themoment.readygsmserver.domain.application.service.QueryApplicationsService;
+import team.themoment.readygsmserver.global.security.annotation.AuthRequest;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @RestController
 @Tag(name = "Application", description = "활동 신청 API")
 @RequestMapping("/api/v1/application")
+@RequiredArgsConstructor
 public class ApplicationController {
+
+    private final ApplyActivityService applyActivityService;
+    private final CancelApplicationService cancelApplicationService;
+    private final QueryApplicationsService queryApplicationsService;
+    private final DeleteApplicationService deleteApplicationService;
+    private final ExportApplicationExcelService exportApplicationExcelService;
 
     @Operation(summary = "활동 신청", description = "활동을 신청합니다.")
     @ApiResponses({
@@ -26,8 +43,8 @@ public class ApplicationController {
             @ApiResponse(responseCode = "409", description = "이미 신청한 활동")
     })
     @PostMapping("/apply")
-    public ApplicationResDto applyActivity(@RequestParam Long activityId, @RequestBody ApplicationReqDto req) {
-        return null;
+    public ApplicationResDto applyActivity(@AuthRequest Long userId, @RequestParam Long activityId, @RequestBody ApplicationReqDto req) {
+        return applyActivityService.execute(userId, activityId, req);
     }
 
     @Operation(summary = "활동 신청 취소", description = "신청된 활동을 신청 취소합니다.")
@@ -37,7 +54,8 @@ public class ApplicationController {
             @ApiResponse(responseCode = "404", description = "신청 내역을 찾을 수 없음")
     })
     @DeleteMapping("/cancel")
-    public void cancelApplication(@RequestParam Long activityId) {
+    public void cancelApplication(@AuthRequest Long userId, @RequestParam Long activityId) {
+        cancelApplicationService.execute(userId, activityId);
     }
 
     @Operation(summary = "신청한 학생 조회", description = "활동을 신청한 학생 목록을 조회합니다.")
@@ -47,8 +65,8 @@ public class ApplicationController {
             @ApiResponse(responseCode = "403", description = "권한 없음")
     })
     @GetMapping("/admin/applications")
-    public List<UserResDto> queryStudents(@RequestParam Long activityId) {
-        return null;
+    public List<ApplicationResDto> queryStudents(@RequestParam Long activityId) {
+        return queryApplicationsService.execute(activityId);
     }
 
     @Operation(summary = "특정 학생 활동 신청 취소", description = "id에 해당하는 학생의 활동 신청을 취소합니다.")
@@ -60,6 +78,7 @@ public class ApplicationController {
     })
     @DeleteMapping("/admin/cancel/{id}")
     public void deleteApplication(@PathVariable Long id) {
+        deleteApplicationService.execute(id);
     }
 
     @Operation(summary = "활동 신청자 엑셀 출력", description = "활동을 신청한 학생 목록을 엑셀로 출력합니다.")
@@ -69,7 +88,15 @@ public class ApplicationController {
             @ApiResponse(responseCode = "403", description = "권한 없음")
     })
     @GetMapping("/admin/excel")
-    public MultipartFile queryApplication(@RequestParam Long activityId) {
-        return null;
+    public ResponseEntity<byte[]> exportExcel(@RequestParam Long activityId) {
+        byte[] excelBytes = exportApplicationExcelService.execute(activityId);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+        headers.setContentDisposition(
+                ContentDisposition.attachment().filename("applications.xlsx", StandardCharsets.UTF_8).build()
+        );
+
+        return ResponseEntity.ok().headers(headers).body(excelBytes);
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/dto/request/ApplicationReqDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/dto/request/ApplicationReqDto.java
@@ -1,12 +1,18 @@
 package team.themoment.readygsmserver.domain.application.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
 public record ApplicationReqDto(
-        String name,
-        Integer grade,
-        Integer classNumber,
-        Integer number,
-        String schoolName,
-        String phoneNumber,
-        String familyPhoneNumber
+        @NotBlank @Size(max = 10) String name,
+        @Min(1) @Max(3) Integer grade,
+        @Min(1) @Max(4) Integer classNumber,
+        @Min(1) @Max(30) Integer number,
+        @NotBlank @Size(max = 200) String schoolName,
+        @NotBlank @Pattern(regexp = "^01[0-9]-\\d{3,4}-\\d{4}$") String phoneNumber,
+        @NotBlank @Pattern(regexp = "^01[0-9]-\\d{3,4}-\\d{4}$") String familyPhoneNumber
 ) {
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/dto/response/ApplicationResDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/dto/response/ApplicationResDto.java
@@ -1,6 +1,6 @@
 package team.themoment.readygsmserver.domain.application.dto.response;
 
-import java.time.LocalDateTime;
+import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
 
 public record ApplicationResDto(
         Long id,
@@ -14,4 +14,18 @@ public record ApplicationResDto(
         String phoneNumber,
         String familyPhoneNumber
 ) {
+    public static ApplicationResDto from(ApplicationJpaEntity entity) {
+        return new ApplicationResDto(
+                entity.getId(),
+                entity.getActivity().getId(),
+                entity.getUser().getId(),
+                entity.getName(),
+                entity.getGrade(),
+                entity.getClassNumber(),
+                entity.getNumber(),
+                entity.getSchoolName(),
+                entity.getPhoneNumber(),
+                entity.getFamilyPhoneNumber()
+        );
+    }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/entity/ApplicationJpaEntity.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/entity/ApplicationJpaEntity.java
@@ -2,8 +2,11 @@ package team.themoment.readygsmserver.domain.application.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
 import team.themoment.readygsmserver.domain.user.entity.UserJpaEntity;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "tb_application", uniqueConstraints = {@UniqueConstraint(columnNames =
@@ -47,4 +50,8 @@ public class ApplicationJpaEntity {
 
     @Column(name = "family_phone_number", nullable = false, length = 20)
     private String familyPhoneNumber;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/entity/ApplicationJpaEntity.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/entity/ApplicationJpaEntity.java
@@ -9,8 +9,10 @@ import team.themoment.readygsmserver.domain.user.entity.UserJpaEntity;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "tb_application", uniqueConstraints = {@UniqueConstraint(columnNames =
-        {"activity_id", "user_id"})})
+@Table(name = "tb_application", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"activity_id", "user_id"}),
+        @UniqueConstraint(columnNames = {"user_id"})
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
@@ -3,6 +3,7 @@ package team.themoment.readygsmserver.domain.application.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
 
 import java.util.List;
@@ -14,5 +15,9 @@ public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntit
 
     @Modifying
     @Query("DELETE FROM ApplicationJpaEntity a WHERE a.activity.id = :activityId AND a.user.id = :userId")
-    int deleteByActivity_IdAndUser_Id(Long activityId, Long userId);
+    int deleteByActivity_IdAndUser_Id(@Param("activityId") Long activityId, @Param("userId") Long userId);
+
+    @Modifying
+    @Query("DELETE FROM ApplicationJpaEntity a WHERE a.id = :id")
+    int deleteByApplicationId(@Param("id") Long id);
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
@@ -1,14 +1,18 @@
 package team.themoment.readygsmserver.domain.application.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntity, Long> {
     boolean existsByUser_Id(Long userId);
-    Optional<ApplicationJpaEntity> findByActivity_IdAndUser_Id(Long activityId, Long userId);
     long countByActivity_Id(Long activityId);
     List<ApplicationJpaEntity> findAllByActivity_Id(Long activityId);
+
+    @Modifying
+    @Query("DELETE FROM ApplicationJpaEntity a WHERE a.activity.id = :activityId AND a.user.id = :userId")
+    int deleteByActivity_IdAndUser_Id(Long activityId, Long userId);
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
@@ -1,0 +1,14 @@
+package team.themoment.readygsmserver.domain.application.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntity, Long> {
+    boolean existsByUser_Id(Long userId);
+    Optional<ApplicationJpaEntity> findByActivity_IdAndUser_Id(Long activityId, Long userId);
+    long countByActivity_Id(Long activityId);
+    List<ApplicationJpaEntity> findAllByActivity_Id(Long activityId);
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
@@ -1,0 +1,69 @@
+package team.themoment.readygsmserver.domain.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
+import team.themoment.readygsmserver.domain.activity.repository.ActivityRepository;
+import team.themoment.readygsmserver.domain.application.dto.request.ApplicationReqDto;
+import team.themoment.readygsmserver.domain.application.dto.response.ApplicationResDto;
+import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
+import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
+import team.themoment.readygsmserver.domain.user.entity.UserJpaEntity;
+import team.themoment.readygsmserver.domain.user.repository.UserRepository;
+import team.themoment.sdk.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ApplyActivityService {
+
+    private final ApplicationRepository applicationRepository;
+    private final ActivityRepository activityRepository;
+    private final UserRepository userRepository;
+
+    public ApplicationResDto execute(Long userId, Long activityId, ApplicationReqDto req) {
+        ActivityJpaEntity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new ExpectedException("활동을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        UserJpaEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        if (applicationRepository.existsByUser_Id(userId)) {
+            throw new ExpectedException("이미 신청한 활동이 있습니다.", HttpStatus.CONFLICT);
+        }
+
+        long currentApplicants = applicationRepository.countByActivity_Id(activityId);
+        if (currentApplicants >= activity.getMaxApplicant()) {
+            throw new ExpectedException("신청 정원이 초과되었습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        ApplicationJpaEntity saved = applicationRepository.save(
+                ApplicationJpaEntity.builder()
+                        .activity(activity)
+                        .user(user)
+                        .name(req.name())
+                        .grade(req.grade())
+                        .classNumber(req.classNumber())
+                        .number(req.number())
+                        .schoolName(req.schoolName())
+                        .phoneNumber(req.phoneNumber())
+                        .familyPhoneNumber(req.familyPhoneNumber())
+                        .build()
+        );
+
+        return new ApplicationResDto(
+                saved.getId(),
+                saved.getActivity().getId(),
+                saved.getUser().getId(),
+                saved.getName(),
+                saved.getGrade(),
+                saved.getClassNumber(),
+                saved.getNumber(),
+                saved.getSchoolName(),
+                saved.getPhoneNumber(),
+                saved.getFamilyPhoneNumber()
+        );
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
@@ -53,17 +53,6 @@ public class ApplyActivityService {
                         .build()
         );
 
-        return new ApplicationResDto(
-                saved.getId(),
-                saved.getActivity().getId(),
-                saved.getUser().getId(),
-                saved.getName(),
-                saved.getGrade(),
-                saved.getClassNumber(),
-                saved.getNumber(),
-                saved.getSchoolName(),
-                saved.getPhoneNumber(),
-                saved.getFamilyPhoneNumber()
-        );
+        return ApplicationResDto.from(saved);
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
@@ -24,7 +24,7 @@ public class ApplyActivityService {
     private final UserRepository userRepository;
 
     public ApplicationResDto execute(Long userId, Long activityId, ApplicationReqDto req) {
-        ActivityJpaEntity activity = activityRepository.findById(activityId)
+        ActivityJpaEntity activity = activityRepository.findByIdWithLock(activityId)
                 .orElseThrow(() -> new ExpectedException("활동을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         UserJpaEntity user = userRepository.findById(userId)

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/CancelApplicationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/CancelApplicationService.java
@@ -15,9 +15,9 @@ public class CancelApplicationService {
     private final ApplicationRepository applicationRepository;
 
     public void execute(Long userId, Long activityId) {
-        applicationRepository.delete(
-                applicationRepository.findByActivity_IdAndUser_Id(activityId, userId)
-                        .orElseThrow(() -> new ExpectedException("신청 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND))
-        );
+        int deleted = applicationRepository.deleteByActivity_IdAndUser_Id(activityId, userId);
+        if (deleted == 0) {
+            throw new ExpectedException("신청 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/CancelApplicationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/CancelApplicationService.java
@@ -1,0 +1,23 @@
+package team.themoment.readygsmserver.domain.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
+import team.themoment.sdk.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CancelApplicationService {
+
+    private final ApplicationRepository applicationRepository;
+
+    public void execute(Long userId, Long activityId) {
+        applicationRepository.delete(
+                applicationRepository.findByActivity_IdAndUser_Id(activityId, userId)
+                        .orElseThrow(() -> new ExpectedException("신청 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND))
+        );
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/DeleteApplicationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/DeleteApplicationService.java
@@ -1,0 +1,23 @@
+package team.themoment.readygsmserver.domain.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
+import team.themoment.sdk.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteApplicationService {
+
+    private final ApplicationRepository applicationRepository;
+
+    public void execute(Long applicationId) {
+        applicationRepository.delete(
+                applicationRepository.findById(applicationId)
+                        .orElseThrow(() -> new ExpectedException("신청 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND))
+        );
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/DeleteApplicationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/DeleteApplicationService.java
@@ -15,9 +15,9 @@ public class DeleteApplicationService {
     private final ApplicationRepository applicationRepository;
 
     public void execute(Long applicationId) {
-        applicationRepository.delete(
-                applicationRepository.findById(applicationId)
-                        .orElseThrow(() -> new ExpectedException("신청 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND))
-        );
+        int deleted = applicationRepository.deleteByApplicationId(applicationId);
+        if (deleted == 0) {
+            throw new ExpectedException("신청 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
@@ -28,6 +28,17 @@ public class ExportApplicationExcelService {
     private static final int COL_PHONE_NUMBER = 5;
     private static final int COL_FAMILY_PHONE_NUMBER = 6;
 
+    // POI 컬럼 너비 단위: 1/256 문자 폭
+    private static final int[] COL_WIDTHS = {
+            10 * 256,  // 이름
+            6 * 256,   // 학년
+            6 * 256,   // 반
+            6 * 256,   // 번호
+            30 * 256,  // 학교명
+            16 * 256,  // 연락처
+            16 * 256   // 보호자 연락처
+    };
+
     private final ApplicationRepository applicationRepository;
 
     public byte[] execute(Long activityId) {
@@ -53,8 +64,8 @@ public class ExportApplicationExcelService {
                 row.createCell(COL_FAMILY_PHONE_NUMBER).setCellValue(app.getFamilyPhoneNumber());
             }
 
-            for (int i = 0; i < HEADERS.length; i++) {
-                sheet.autoSizeColumn(i);
+            for (int i = 0; i < COL_WIDTHS.length; i++) {
+                sheet.setColumnWidth(i, COL_WIDTHS[i]);
             }
 
             ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
@@ -1,0 +1,63 @@
+package team.themoment.readygsmserver.domain.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
+import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExportApplicationExcelService {
+
+    private static final String[] HEADERS = {"이름", "학년", "반", "번호", "학교명", "연락처", "보호자 연락처"};
+
+    private static final int COL_NAME = 0;
+    private static final int COL_GRADE = 1;
+    private static final int COL_CLASS_NUMBER = 2;
+    private static final int COL_NUMBER = 3;
+    private static final int COL_SCHOOL_NAME = 4;
+    private static final int COL_PHONE_NUMBER = 5;
+    private static final int COL_FAMILY_PHONE_NUMBER = 6;
+
+    private final ApplicationRepository applicationRepository;
+
+    public byte[] execute(Long activityId) {
+        List<ApplicationJpaEntity> applications = applicationRepository.findAllByActivity_Id(activityId);
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("신청자 목록");
+
+            Row headerRow = sheet.createRow(0);
+            for (int i = 0; i < HEADERS.length; i++) {
+                headerRow.createCell(i).setCellValue(HEADERS[i]);
+            }
+
+            for (int i = 0; i < applications.size(); i++) {
+                ApplicationJpaEntity app = applications.get(i);
+                Row row = sheet.createRow(i + 1);
+                row.createCell(COL_NAME).setCellValue(app.getName());
+                row.createCell(COL_GRADE).setCellValue(app.getGrade());
+                row.createCell(COL_CLASS_NUMBER).setCellValue(app.getClassNumber());
+                row.createCell(COL_NUMBER).setCellValue(app.getNumber());
+                row.createCell(COL_SCHOOL_NAME).setCellValue(app.getSchoolName());
+                row.createCell(COL_PHONE_NUMBER).setCellValue(app.getPhoneNumber());
+                row.createCell(COL_FAMILY_PHONE_NUMBER).setCellValue(app.getFamilyPhoneNumber());
+            }
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            workbook.write(out);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("엑셀 파일 생성에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
@@ -53,6 +53,10 @@ public class ExportApplicationExcelService {
                 row.createCell(COL_FAMILY_PHONE_NUMBER).setCellValue(app.getFamilyPhoneNumber());
             }
 
+            for (int i = 0; i < HEADERS.length; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             workbook.write(out);
             return out.toByteArray();

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/QueryApplicationsService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/QueryApplicationsService.java
@@ -17,18 +17,7 @@ public class QueryApplicationsService {
 
     public List<ApplicationResDto> execute(Long activityId) {
         return applicationRepository.findAllByActivity_Id(activityId).stream()
-                .map(a -> new ApplicationResDto(
-                        a.getId(),
-                        a.getActivity().getId(),
-                        a.getUser().getId(),
-                        a.getName(),
-                        a.getGrade(),
-                        a.getClassNumber(),
-                        a.getNumber(),
-                        a.getSchoolName(),
-                        a.getPhoneNumber(),
-                        a.getFamilyPhoneNumber()
-                ))
+                .map(ApplicationResDto::from)
                 .toList();
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/QueryApplicationsService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/QueryApplicationsService.java
@@ -1,0 +1,34 @@
+package team.themoment.readygsmserver.domain.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.application.dto.response.ApplicationResDto;
+import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QueryApplicationsService {
+
+    private final ApplicationRepository applicationRepository;
+
+    public List<ApplicationResDto> execute(Long activityId) {
+        return applicationRepository.findAllByActivity_Id(activityId).stream()
+                .map(a -> new ApplicationResDto(
+                        a.getId(),
+                        a.getActivity().getId(),
+                        a.getUser().getId(),
+                        a.getName(),
+                        a.getGrade(),
+                        a.getClassNumber(),
+                        a.getNumber(),
+                        a.getSchoolName(),
+                        a.getPhoneNumber(),
+                        a.getFamilyPhoneNumber()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PUBLIC_PATHS).permitAll()
+                        .requestMatchers("/api/v1/application/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.session.web.http.CookieSerializer;
 import org.springframework.session.web.http.DefaultCookieSerializer;
+import team.themoment.readygsmserver.domain.user.entity.constant.Role;
 
 @Configuration
 @EnableWebSecurity
@@ -39,7 +40,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PUBLIC_PATHS).permitAll()
-                        .requestMatchers("/api/v1/application/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/v1/application/admin/**").hasAuthority(Role.ADMIN.getAuthority())
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,7 +43,6 @@ spring:
 server:
   port: 8080
   servlet:
-    context-path: /ready-gsm
     session:
       timeout: 3h
   forward-headers-strategy: framework
@@ -73,8 +72,6 @@ sdk:
       - "/v3/api-docs/**"
       - "/swagger-ui/**"
       - "/api/v1/auth/callback"
-      - "/ready-gsm/v3/api-docs/**"
-      - "/ready-gsm/swagger-ui/**"
 
   response:
     enabled: true
@@ -82,11 +79,7 @@ sdk:
       - "/v3/api-docs/**"
       - "/v3/api-docs"
       - "/swagger-ui/**"
-      - "/ready-gsm/v3/api-docs/**"
-      - "/ready-gsm/v3/api-docs"
-      - "/ready-gsm/swagger-ui/**"
       - "/api/v1/application/admin/excel"
-      - "/ready-gsm/api/v1/application/admin/excel"
 
   exception:
     enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,6 +85,8 @@ sdk:
       - "/ready-gsm/v3/api-docs/**"
       - "/ready-gsm/v3/api-docs"
       - "/ready-gsm/swagger-ui/**"
+      - "/api/v1/application/admin/excel"
+      - "/ready-gsm/api/v1/application/admin/excel"
 
   exception:
     enabled: true


### PR DESCRIPTION
## 개요

활동 신청 관련 전체 기능을 구현했습니다.
유저는 전체 활동 중 단 하나만 신청할 수 있으며, 관리자는 신청 목록 조회 및 관리가 가능합니다.

---

## 구현 내용

### 신규 생성 파일

| 파일 | 설명 |
|---|---|
| `ActivityRepository` | 활동 조회 (Pessimistic Lock 포함) |
| `ApplicationRepository` | 신청 조회/카운트 쿼리 |
| `ApplyActivityService` | 활동 신청 |
| `CancelApplicationService` | 활동 신청 취소 |
| `QueryApplicationsService` | 신청자 목록 조회 (관리자) |
| `DeleteApplicationService` | 특정 신청 삭제 (관리자) |
| `ExportApplicationExcelService` | 신청자 엑셀 다운로드 (관리자) |

### 수정 파일

| 파일 | 변경 내용 |
|---|---|
| `ApplicationController` | 5개 엔드포인트 서비스 연결, `@Valid` 추가 |
| `ApplicationReqDto` | Bean Validation 어노테이션 추가 |
| `ApplicationResDto` | `from()` 팩토리 메서드 추가 |
| `ApplicationJpaEntity` | `createdAt` 필드 추가 |
| `SecurityConfig` | `/admin/**` 경로에 `ROLE_ADMIN` 권한 적용 |
| `build.gradle` | Apache POI 5.5.1 의존성 추가 |

---

## API

| 메서드 | 경로 | 설명 | 권한 |
|---|---|---|---|
| `POST` | `/api/v1/application/apply` | 활동 신청 | USER |
| `DELETE` | `/api/v1/application/cancel` | 활동 신청 취소 | USER |
| `GET` | `/api/v1/application/admin/applications` | 신청자 목록 조회 | ADMIN |
| `DELETE` | `/api/v1/application/admin/cancel/{id}` | 신청 취소 (관리자) | ADMIN |
| `GET` | `/api/v1/application/admin/excel` | 신청자 엑셀 다운로드 | ADMIN |

---

## 주요 설계 결정

### 유저 1:1 신청 제약
유저는 전체 활동 중 단 하나만 신청할 수 있습니다.
`existsByUser_Id()`로 기존 신청 여부를 먼저 확인하고, 이미 신청 내역이 있으면 409를 반환합니다.

### Race Condition 방지
정원 초과 검증 시 `countByActivity_Id()` 후 `save()` 사이에 동시 요청이 끼어들 수 있는 문제를 Pessimistic Lock으로 해결했습니다.
`ActivityRepository.findByIdWithLock()`으로 활동 행에 배타락을 걸어 동시 신청을 직렬화합니다.

### 엑셀 다운로드
Apache POI(XLSX)를 사용하며, `ResponseEntity<byte[]>`로 반환합니다.
컬럼 너비는 `autoSizeColumn()`으로 자동 조정됩니다.

---

## 예외 처리

| 상황 | HTTP 상태 |
|---|---|
| 활동 없음 | 404 |
| 유저 없음 | 404 |
| 이미 신청한 유저 | 409 |
| 정원 초과 | 400 |
| 신청 내역 없음 (취소) | 404 |
| 입력값 유효성 오류 | 400 |
| 미인증 | 401 |
| 권한 없음 (admin) | 403 |
