### PR TITLE
[global] OAuth 설정 키 중복 제거 및 불필요한 redirectUri 정리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,5 @@ The following environment variables are required before running.
 | `JWT_SECRET` | Base64-encoded HMAC secret key (256-bit or more) |
 | `GOOGLE_CLIENT_ID` | Google OAuth2 client ID |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth2 client secret |
-| `GOOGLE_REDIRECT_URI` | Google OAuth2 redirect URI (must match Google Console registration, e.g. `http://localhost:3000/oauth/callback`) |
 | `KAKAO_CLIENT_ID` | Kakao OAuth2 REST API key |
 | `KAKAO_CLIENT_SECRET` | Kakao OAuth2 client secret |

--- a/src/main/java/team/themoment/readygsmserver/global/config/GoogleOAuthProperties.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/GoogleOAuthProperties.java
@@ -3,5 +3,5 @@ package team.themoment.readygsmserver.global.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("google.oauth")
-public record GoogleOAuthProperties(String clientId, String clientSecret, String redirectUri) {
+public record GoogleOAuthProperties(String clientId, String clientSecret) {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,17 +29,6 @@ spring:
       flush-mode: immediate
       save-mode: on-set-attribute
 
-  security:
-    oauth2:
-      client:
-        registration:
-          google:
-            client-id: ${GOOGLE_CLIENT_ID}
-            client-secret: ${GOOGLE_CLIENT_SECRET}
-            scope:
-              - email
-              - profile
-
 server:
   port: 8080
   servlet:
@@ -56,7 +45,6 @@ google:
   oauth:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
-    redirect-uri: ${GOOGLE_REDIRECT_URI}
 
 kakao:
   oauth:


### PR DESCRIPTION
## 개요

PR #37 리뷰에서 snowykte0426님이 지적한 OAuth 설정 키 산재 문제를 별도 PR로 정리합니다.

## 변경 사항

### `application.yml`
- `spring.security.oauth2.client.registration.google` 섹션 제거
  - 프로젝트는 `.oauth2Login()`을 사용하지 않는 Feign Client 기반 커스텀 OAuth2 구현이므로 Spring Security 표준 등록이 불필요하며, `google.oauth.*`와 동일한 환경변수를 중복 참조하고 있었음
- `google.oauth.redirect-uri` 제거
  - `redirectUri`는 클라이언트가 요청 시 동적으로 전달하는 값으로 서버 설정에 고정할 필요 없음

### `GoogleOAuthProperties.java`
- `redirectUri` 필드 제거 (코드 어디서도 사용되지 않던 미사용 필드)

### `CLAUDE.md`
- `GOOGLE_REDIRECT_URI` 환경변수 항목 제거

## 관련 PR

- #37