### PR TITLE
[user] 내 정보 조회 API 추가 및 신규 가입 역할 USER로 변경

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/user/controller/UserController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/controller/UserController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,7 +27,7 @@ public class UserController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
     @GetMapping("/me")
-    public ResponseEntity<UserResDto> getMe(@AuthenticationPrincipal OAuth2User user) {
-        return ResponseEntity.ok(userService.getMe(user));
+    public UserResDto getMe(@AuthenticationPrincipal OAuth2User user) {
+        return userService.getMe(user);
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/user/controller/UserController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/controller/UserController.java
@@ -1,0 +1,32 @@
+package team.themoment.readygsmserver.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team.themoment.readygsmserver.domain.user.dto.response.UserResDto;
+import team.themoment.readygsmserver.domain.user.service.UserService;
+
+@RestController
+@Tag(name = "User", description = "유저 API")
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 유저의 정보를 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @GetMapping("/me")
+    public ResponseEntity<UserResDto> getMe() {
+        return ResponseEntity.ok(userService.getMe());
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/user/controller/UserController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/controller/UserController.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,7 +28,7 @@ public class UserController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
     @GetMapping("/me")
-    public ResponseEntity<UserResDto> getMe() {
-        return ResponseEntity.ok(userService.getMe());
+    public ResponseEntity<UserResDto> getMe(@AuthenticationPrincipal OAuth2User user) {
+        return ResponseEntity.ok(userService.getMe(user));
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/user/entity/UserJpaEntity.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/entity/UserJpaEntity.java
@@ -39,7 +39,7 @@ public class UserJpaEntity {
         return UserJpaEntity.builder()
                 .email(email)
                 .authReferrerType(authReferrerType)
-                .role(Role.UNAUTHENTICATED)
+                .role(Role.USER)
                 .lastLoginTime(LocalDateTime.now())
                 .build();
     }

--- a/src/main/java/team/themoment/readygsmserver/domain/user/service/UserService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/service/UserService.java
@@ -1,8 +1,5 @@
 package team.themoment.readygsmserver.domain.user.service;
 
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import team.themoment.readygsmserver.domain.user.dto.response.UserResDto;
@@ -10,17 +7,10 @@ import team.themoment.readygsmserver.domain.user.dto.response.UserResDto;
 @Service
 public class UserService {
 
-    public UserResDto getMe() {
-        var authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication instanceof OAuth2AuthenticationToken token) {
-            OAuth2User user = token.getPrincipal();
-            Long id = ((Number) user.getAttribute("id")).longValue();
-            String email = user.getAttribute("email");
-            String role = user.getAttribute("role");
-            return new UserResDto(id, email, role);
-        }
-
-        throw new AccessDeniedException("인증 정보가 없습니다.");
+    public UserResDto getMe(OAuth2User user) {
+        Long id = ((Number) user.getAttribute("id")).longValue();
+        String email = user.getAttribute("email");
+        String role = user.getAttribute("role");
+        return new UserResDto(id, email, role);
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/user/service/UserService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/service/UserService.java
@@ -1,0 +1,26 @@
+package team.themoment.readygsmserver.domain.user.service;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import team.themoment.readygsmserver.domain.user.dto.response.UserResDto;
+
+@Service
+public class UserService {
+
+    public UserResDto getMe() {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication instanceof OAuth2AuthenticationToken token) {
+            OAuth2User user = token.getPrincipal();
+            Long id = ((Number) user.getAttribute("id")).longValue();
+            String email = user.getAttribute("email");
+            String role = user.getAttribute("role");
+            return new UserResDto(id, email, role);
+        }
+
+        throw new AccessDeniedException("인증 정보가 없습니다.");
+    }
+}


### PR DESCRIPTION
## 개요

프론트엔드에서 로그인 후 유저 role 기반 분기 처리를 위해 필요한 `/me` API를 추가하고, 신규 가입 시 role 부여 로직을 수정합니다.

## 변경 사항

### `UserJpaEntity.java`
- 신규 OAuth 가입 시 `Role.UNAUTHENTICATED` → `Role.USER` 로 변경
  - 기존에는 가입 후 role을 변경할 수단이 없어 영구적으로 `UNAUTHENTICATED` 상태가 되는 문제 존재

### `UserService.java` (신규)
- SecurityContext에 저장된 OAuth2User 속성에서 유저 정보 조회 (DB 조회 없음)

### `UserController.java` (신규)
- `GET /api/v1/user/me` 엔드포인트 추가
- 응답: `id`, `email`, `role`
- 인증된 사용자만 접근 가능 (세션 쿠키 필요)

## API 명세

```
GET /api/v1/user/me

Response 200
{
  "id": 1,
  "email": "example@gsm.hs.kr",
  "role": "USER"
}
```