### PR TITLE
[global] OAuth 잘못된 요청 시 200 반환 문제 수정 및 stage URI 변경

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/auth/service/OAuthAuthenticationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/service/OAuthAuthenticationService.java
@@ -11,6 +11,7 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.readygsmserver.domain.auth.dto.UserAuthInfo;
 import team.themoment.readygsmserver.domain.user.entity.UserJpaEntity;
@@ -18,6 +19,7 @@ import team.themoment.readygsmserver.domain.user.repository.UserRepository;
 import team.themoment.readygsmserver.global.security.oauth2.OAuth2Properties;
 import team.themoment.readygsmserver.global.security.oauth2.OAuthProviderFactory;
 import team.themoment.readygsmserver.global.security.oauth2.provider.OAuthProvider;
+import team.themoment.sdk.exception.ExpectedException;
 
 import java.util.List;
 import java.util.Map;
@@ -77,10 +79,10 @@ public class OAuthAuthenticationService {
 
     private void validateRedirectUri(String redirectUri) {
         if (redirectUri == null || redirectUri.isBlank()) {
-            throw new IllegalArgumentException("redirect_uri는 필수입니다.");
+            throw new ExpectedException("redirect_uri는 필수입니다.", HttpStatus.BAD_REQUEST);
         }
         if (!oauth2Properties.allowedRedirectUris().contains(redirectUri)) {
-            throw new IllegalArgumentException("허용되지 않은 redirect_uri입니다: " + redirectUri);
+            throw new ExpectedException("허용되지 않은 redirect_uri입니다.", HttpStatus.BAD_REQUEST);
         }
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/global/security/oauth2/OAuthProviderFactory.java
+++ b/src/main/java/team/themoment/readygsmserver/global/security/oauth2/OAuthProviderFactory.java
@@ -23,7 +23,7 @@ public class OAuthProviderFactory {
     public OAuthProvider getProvider(String providerName) {
         OAuthProvider provider = providerMap.get(providerName.trim().toLowerCase());
         if (provider == null) {
-            throw new ExpectedException("지원하지 않는 OAuth 제공자입니다.", HttpStatus.BAD_REQUEST);
+            throw new ExpectedException("지원하지 않는 OAuth 제공자입니다: " + providerName, HttpStatus.BAD_REQUEST);
         }
         return provider;
     }

--- a/src/main/java/team/themoment/readygsmserver/global/security/oauth2/OAuthProviderFactory.java
+++ b/src/main/java/team/themoment/readygsmserver/global/security/oauth2/OAuthProviderFactory.java
@@ -1,7 +1,9 @@
 package team.themoment.readygsmserver.global.security.oauth2;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import team.themoment.readygsmserver.global.security.oauth2.provider.OAuthProvider;
+import team.themoment.sdk.exception.ExpectedException;
 
 import java.util.List;
 import java.util.Map;
@@ -21,7 +23,7 @@ public class OAuthProviderFactory {
     public OAuthProvider getProvider(String providerName) {
         OAuthProvider provider = providerMap.get(providerName.trim().toLowerCase());
         if (provider == null) {
-            throw new IllegalArgumentException("지원하지 않는 OAuth 제공자입니다: " + providerName);
+            throw new ExpectedException("지원하지 않는 OAuth 제공자입니다.", HttpStatus.BAD_REQUEST);
         }
         return provider;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,7 +57,7 @@ oauth2:
   failure-redirect-url: ${OAUTH2_FAILURE_REDIRECT_URL:/}
   allowed-redirect-uris:
     - "http://localhost:3000/oauth/callback"
-    - "https://stage.readygsm.kr/oauth/callback"
+    - "https://kimtaeeun.site/ready-gsm/oauth/callback"
     - "https://www.readygsm.kr/oauth/callback"
 
 sdk:


### PR DESCRIPTION
## 개요

OAuth 인증 흐름에서 발생하던 두 가지 문제를 수정하였습니다.

1. `IllegalArgumentException` 사용으로 인해 잘못된 요청임에도 200이 반환되던 문제
2. Stage 환경 주소 변경에 따른 redirect URI 불일치 문제

## 변경 사항

### 예외 타입을 ExpectedException으로 교체

`OAuthAuthenticationService.validateRedirectUri()`와 `OAuthProviderFactory.getProvider()`에서 `IllegalArgumentException`을 사용하고 있었습니다.

해당 예외는 SDK의 전역 예외 핸들러가 처리하지 못하여, 허용되지 않은 `redirectUri`나 미지원 provider로 요청하여도 400이 아닌 200이 반환되는 문제가 있었습니다.

`ExpectedException(message, HttpStatus.BAD_REQUEST)`으로 교체하여 올바른 에러 응답이 반환되도록 수정하였습니다.

**변경 파일:**
- `OAuthAuthenticationService.java` — `validateRedirectUri()` 예외 교체
- `OAuthProviderFactory.java` — `getProvider()` 예외 교체

### Stage redirect URI 변경

Stage 환경 도메인이 `stage.readygsm.kr`에서 `kimtaeeun.site/ready-gsm`으로 변경되었습니다.

`application.yml`의 `allowed-redirect-uris`에 등록된 stage URI를 변경하였습니다.

| | URI |
|---|---|
| 변경 전 | `https://stage.readygsm.kr/oauth/callback` |
| 변경 후 | `https://kimtaeeun.site/ready-gsm/oauth/callback` |

**변경 파일:**
- `application.yml`

## 주의 사항

Kakao 개발자 콘솔과 Google Cloud Console의 redirect URI도 `https://kimtaeeun.site/ready-gsm/oauth/callback`으로 변경이 필요합니다.