### PR TITLE
[user] auth_referrer_type 컬럼 타입을 VARCHAR(50)으로 변경

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/user/entity/UserJpaEntity.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/entity/UserJpaEntity.java
@@ -24,7 +24,7 @@ public class UserJpaEntity {
     private String email;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "auth_referrer_type", nullable = false)
+    @Column(name = "auth_referrer_type", nullable = false, columnDefinition = "VARCHAR(50)")
     private AuthReferrerType authReferrerType;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## 개요

`auth_referrer_type` 컬럼 타입을 MySQL ENUM에서 VARCHAR(50)으로 변경하였습니다.

## 변경 원인

Hibernate + MySQLDialect 환경에서 `@Enumerated(EnumType.STRING)`은 기본적으로 MySQL ENUM 타입 컬럼을 생성합니다.
카카오 OAuth 추가로 `AuthReferrerType` enum에 `KAKAO` 값이 추가되었으나, `ddl-auto: update` 전략은 기존 ENUM 컬럼의 허용값 목록을 자동으로 갱신하지 않습니다.
그 결과, 카카오 로그인 시 신규 사용자 INSERT에서 `Data truncated for column 'auth_referrer_type'` 에러가 발생하였고 세션이 생성되지 않아 로그인이 실패하는 현상이 발생하였습니다.

## 변경 사항

- `UserJpaEntity.authReferrerType` 필드의 `@Column`에 `columnDefinition = "VARCHAR(50)"` 추가
- 이후 enum 값이 추가되어도 DB 컬럼 수정 없이 동작하도록 개선

## 주의 사항

이미 운영 중인 DB에는 `ddl-auto: update`가 기존 컬럼 타입 변경을 적용하지 않으므로, 하기 쿼리를 직접 실행하여야 합니다.

```sql
ALTER TABLE tb_user MODIFY COLUMN auth_referrer_type VARCHAR(50) NOT NULL;
```