### PR TITLE
[activity] Activity 엔드포인트 권한 구조 개선

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
@@ -18,8 +18,7 @@ public class ActivityController {
 
     @Operation(summary = "전체 활동 조회", description = "서비스에 등록되어 있는 모든 활동 목록과 각 정보를 조회합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+            @ApiResponse(responseCode = "200", description = "조회 성공")
     })
     @GetMapping
     public List<ActivityResDto> queryAllActivities() {
@@ -29,7 +28,6 @@ public class ActivityController {
     @Operation(summary = "활동 단일 조회", description = "활동 정보를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
             @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없음")
     })
     @GetMapping("/{id}")
@@ -44,7 +42,7 @@ public class ActivityController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
             @ApiResponse(responseCode = "403", description = "권한 없음")
     })
-    @PostMapping
+    @PostMapping("/admin")
     public ActivityResDto createActivity(@RequestBody ActivityReqDto req) {
         return null;
     }
@@ -57,7 +55,7 @@ public class ActivityController {
             @ApiResponse(responseCode = "403", description = "권한 없음"),
             @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없음")
     })
-    @PatchMapping("/{id}")
+    @PatchMapping("/admin/{id}")
     public ActivityResDto editActivity(@PathVariable Long id, @RequestBody ActivityReqDto req) {
         return null;
     }
@@ -69,7 +67,7 @@ public class ActivityController {
             @ApiResponse(responseCode = "403", description = "권한 없음"),
             @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없음")
     })
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/admin/{id}")
     public void deleteActivity(@PathVariable Long id) {
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
     private static final String[] PUBLIC_PATHS = {
             "/api/v1/auth/**",
             "/api/v1/activity",
-            "/api/v1/activity/**",
+            "/api/v1/activity/*",
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/v3/api-docs",

--- a/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
@@ -21,6 +21,8 @@ public class SecurityConfig {
 
     private static final String[] PUBLIC_PATHS = {
             "/api/v1/auth/**",
+            "/api/v1/activity",
+            "/api/v1/activity/**",
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/v3/api-docs",
@@ -40,8 +42,9 @@ public class SecurityConfig {
                         .securityContextRepository(securityContextRepository())
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(PUBLIC_PATHS).permitAll()
+                        .requestMatchers("/api/v1/activity/admin/**").hasAuthority(Role.ADMIN.getAuthority())
                         .requestMatchers("/api/v1/application/admin/**").hasAuthority(Role.ADMIN.getAuthority())
+                        .requestMatchers(PUBLIC_PATHS).permitAll()
                         .anyRequest().authenticated()
                 );
 


### PR DESCRIPTION
## 개요

Activity API의 엔드포인트 경로 구조를 개선하여 어드민 전용 기능에 `/admin` 경로를 추가하고, SecurityConfig의 권한 규칙을 단순화하였습니다.

## 변경 원인

기존 구조에서는 HTTP 메서드(POST, PATCH, DELETE)로만 ADMIN 권한을 구분하여 SecurityConfig에 메서드별 규칙이 나열되어 있었습니다.
`ApplicationController`가 이미 `/admin` 경로 패턴을 사용하고 있어, `ActivityController`도 동일한 패턴을 적용해 일관성을 맞추고 SecurityConfig를 단순화하였습니다.

## 변경 사항

- `ActivityController` 어드민 전용 엔드포인트에 `/admin` 경로 추가
  - `POST /api/v1/activity/admin`
  - `PATCH /api/v1/activity/admin/{id}`
  - `DELETE /api/v1/activity/admin/{id}`
- public 엔드포인트(`GET /api/v1/activity`, `GET /api/v1/activity/{id}`)에서 불필요한 401 응답 스펙 제거
- `SecurityConfig`에서 메서드별 세분화 규칙 제거 후 `/admin/**` 경로 기반 단일 규칙으로 통합