### PR TITLE
[user] 개발용 사용자 role 변경 API 및 ROOT role 추가

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/user/controller/UtilityController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/controller/UtilityController.java
@@ -1,0 +1,32 @@
+package team.themoment.readygsmserver.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.*;
+import team.themoment.readygsmserver.domain.user.entity.constant.Role;
+import team.themoment.readygsmserver.domain.user.service.ModifyUserRoleService;
+
+@RestController
+@Tag(name = "Utility", description = "개발용 유틸리티 API")
+@RequestMapping("/api/v1/utility")
+@RequiredArgsConstructor
+@Profile("!prod")
+public class UtilityController {
+
+    private final ModifyUserRoleService modifyUserRoleService;
+
+    @Operation(summary = "사용자 권한 수정", description = "입력된 이메일에 해당하는 사용자의 권한을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용자 권한 수정 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 이메일에 해당하는 계정이 존재하지 않음")
+    })
+    @PatchMapping("/user/role")
+    public String updateUserRole(@RequestParam String email, @RequestParam Role role) {
+        modifyUserRoleService.execute(email, role);
+        return "입력된 이메일에 해당하는 사용자의 권한을 수정했습니다. 이메일: " + email + ", 권한: " + role;
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/user/entity/UserJpaEntity.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/entity/UserJpaEntity.java
@@ -47,4 +47,8 @@ public class UserJpaEntity {
     public void updateLastLoginTime() {
         this.lastLoginTime = LocalDateTime.now();
     }
+
+    public void modifyRole(Role role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/user/entity/constant/Role.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/entity/constant/Role.java
@@ -5,7 +5,8 @@ import org.springframework.security.core.GrantedAuthority;
 public enum Role implements GrantedAuthority {
     UNAUTHENTICATED,
     USER,
-    ADMIN;
+    ADMIN,
+    ROOT;
 
     @Override
     public String getAuthority() {

--- a/src/main/java/team/themoment/readygsmserver/domain/user/repository/UserRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/repository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<UserJpaEntity, Long> {
     Optional<UserJpaEntity> findByAuthReferrerTypeAndEmail(AuthReferrerType authReferrerType, String email);
+    Optional<UserJpaEntity> findByEmail(String email);
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/user/service/ModifyUserRoleService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/service/ModifyUserRoleService.java
@@ -1,0 +1,26 @@
+package team.themoment.readygsmserver.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.user.entity.UserJpaEntity;
+import team.themoment.readygsmserver.domain.user.entity.constant.Role;
+import team.themoment.readygsmserver.domain.user.repository.UserRepository;
+import team.themoment.sdk.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+@Profile("!prod")
+public class ModifyUserRoleService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void execute(String email, Role role) {
+        UserJpaEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ExpectedException("해당 이메일에 해당하는 계정이 존재하지 않습니다.", HttpStatus.NOT_FOUND));
+        user.modifyRole(role);
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package team.themoment.readygsmserver.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -23,6 +25,7 @@ public class SecurityConfig {
             "/api/v1/auth/**",
             "/api/v1/activity",
             "/api/v1/activity/*",
+            "/api/v1/utility/**",
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/v3/api-docs",
@@ -54,6 +57,14 @@ public class SecurityConfig {
     @Bean
     public SecurityContextRepository securityContextRepository() {
         return new HttpSessionSecurityContextRepository();
+    }
+
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        return RoleHierarchyImpl.fromHierarchy(
+                Role.ROOT.getAuthority() + " > " + Role.ADMIN.getAuthority() + "\n" +
+                Role.ADMIN.getAuthority() + " > " + Role.USER.getAuthority()
+        );
     }
 
     @Bean

--- a/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
             "/api/v1/auth/**",
             "/api/v1/activity",
             "/api/v1/activity/*",
-            "/api/v1/utility/**",
+            "/api/v1/utility/user/role",
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/v3/api-docs",


### PR DESCRIPTION
## 개요

개발 편의를 위한 사용자 role 변경 API와 `ROOT` 역할을 추가하였습니다.
해당 기능은 `@Profile("!prod")` 설정을 통해 운영 환경에서는 비활성화되도록 구성하였습니다.

## 변경 사항

### 개발용 role 변경 API 추가

- `PATCH /api/v1/utility/user/role?email={email}&role={role}` 엔드포인트를 추가하였습니다.
- 이메일을 기준으로 사용자를 조회하여 role을 변경하도록 구현하였습니다.
- `UtilityController`, `ModifyUserRoleService`를 신규 생성하였습니다.
- `UserJpaEntity`에 `modifyRole()` 메서드를 추가하였습니다.
- `UserRepository`에 `findByEmail()` 메서드를 추가하였습니다.
- `/api/v1/utility/**` 경로를 `SecurityConfig` 공개 경로에 추가하였습니다.

### ROOT role 추가

- `Role` enum에 `ROOT` 값을 추가하였습니다.
- `SecurityConfig`에 `RoleHierarchy` Bean을 등록하여 `ROOT > ADMIN > USER` 계층 구조를 적용하였습니다.
- `ROOT` role은 `ADMIN`, `USER` 권한이 필요한 모든 경로에 접근 가능하도록 구성하였습니다.

## 참고 사항

- role 컬럼은 `@Enumerated(EnumType.STRING)` 기반 `VARCHAR` 타입이므로 별도 DB 마이그레이션은 불필요합니다.
- `RoleHierarchy` Bean은 Spring Security의 `authorizeHttpRequests`에 자동 적용됩니다.