### PR TITLE
[auth] 로그아웃 API 추가

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import team.themoment.readygsmserver.domain.auth.dto.request.OAuthCodeRequest;
 import team.themoment.readygsmserver.domain.auth.service.LogoutService;
 import team.themoment.readygsmserver.domain.auth.service.OAuthAuthenticationService;
+import team.themoment.sdk.response.CommonApiResponse;
 
 @RestController
 @Tag(name = "Auth", description = "인증 API")
@@ -24,8 +25,9 @@ public class AuthController {
     @Operation(summary = "로그아웃", description = "현재 세션을 만료시킵니다.")
     @ApiResponse(responseCode = "200", description = "로그아웃 완료")
     @PostMapping("/logout")
-    public void logout(HttpServletRequest request) {
+    public CommonApiResponse logout(HttpServletRequest request) {
         logoutService.execute(request);
+        return CommonApiResponse.success("로그아웃 완료");
     }
 
     @Operation(summary = "OAuth 로그인", description = "프론트엔드에서 Authorization Code와 redirect_uri를 전달해 로그인합니다.")

--- a/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
@@ -5,8 +5,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import team.themoment.readygsmserver.domain.auth.dto.request.OAuthCodeRequest;
 import team.themoment.readygsmserver.domain.auth.service.OAuthAuthenticationService;
@@ -18,6 +20,18 @@ import team.themoment.readygsmserver.domain.auth.service.OAuthAuthenticationServ
 public class AuthController {
 
     private final OAuthAuthenticationService oAuthAuthenticationService;
+
+    @Operation(summary = "로그아웃", description = "현재 세션을 만료시킵니다.")
+    @ApiResponse(responseCode = "200", description = "로그아웃 완료")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
+        SecurityContextHolder.clearContext();
+        return ResponseEntity.ok().build();
+    }
 
     @Operation(summary = "OAuth 로그인", description = "프론트엔드에서 Authorization Code와 redirect_uri를 전달해 로그인합니다.")
     @ApiResponses({

--- a/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
@@ -5,12 +5,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import team.themoment.readygsmserver.domain.auth.dto.request.OAuthCodeRequest;
+import team.themoment.readygsmserver.domain.auth.service.LogoutService;
 import team.themoment.readygsmserver.domain.auth.service.OAuthAuthenticationService;
 
 @RestController
@@ -20,16 +19,13 @@ import team.themoment.readygsmserver.domain.auth.service.OAuthAuthenticationServ
 public class AuthController {
 
     private final OAuthAuthenticationService oAuthAuthenticationService;
+    private final LogoutService logoutService;
 
     @Operation(summary = "로그아웃", description = "현재 세션을 만료시킵니다.")
     @ApiResponse(responseCode = "200", description = "로그아웃 완료")
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletRequest request) {
-        HttpSession session = request.getSession(false);
-        if (session != null) {
-            session.invalidate();
-        }
-        SecurityContextHolder.clearContext();
+        logoutService.execute(request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/controller/AuthController.java
@@ -24,9 +24,8 @@ public class AuthController {
     @Operation(summary = "로그아웃", description = "현재 세션을 만료시킵니다.")
     @ApiResponse(responseCode = "200", description = "로그아웃 완료")
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(HttpServletRequest request) {
+    public void logout(HttpServletRequest request) {
         logoutService.execute(request);
-        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "OAuth 로그인", description = "프론트엔드에서 Authorization Code와 redirect_uri를 전달해 로그인합니다.")

--- a/src/main/java/team/themoment/readygsmserver/domain/auth/service/LogoutService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/auth/service/LogoutService.java
@@ -1,0 +1,18 @@
+package team.themoment.readygsmserver.domain.auth.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LogoutService {
+
+    public void execute(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
+        SecurityContextHolder.clearContext();
+    }
+}


### PR DESCRIPTION
## 개요

PR #45가 실수로 `master`에 머지되어 revert 후 `develop`으로 재머지합니다.

## 변경 사항

- `AuthController`에 `POST /api/v1/auth/logout` 엔드포인트 추가
- `LogoutService`로 로그아웃 로직 분리
- `HttpSession.invalidate()` 호출로 Redis 세션 삭제
- `SecurityContextHolder.clearContext()` 호출로 인증 정보 제거
- 미로그인 상태로 호출해도 200 반환

## 관련 PR

- 원본: #45
- master revert: #48