### PR TITLE
[activity] 학과 체험 서비스 계층 구현 및 컨트롤러 완성

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/controller/ActivityController.java
@@ -4,17 +4,31 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import team.themoment.readygsmserver.domain.activity.dto.request.ActivityReqDto;
 import team.themoment.readygsmserver.domain.activity.dto.response.ActivityResDto;
+import team.themoment.readygsmserver.domain.activity.service.CreateActivityService;
+import team.themoment.readygsmserver.domain.activity.service.DeleteActivityService;
+import team.themoment.readygsmserver.domain.activity.service.EditActivityService;
+import team.themoment.readygsmserver.domain.activity.service.QueryActivityService;
+import team.themoment.readygsmserver.domain.activity.service.QueryAllActivitiesService;
 
 import java.util.List;
 
 @RestController
 @Tag(name = "Activity", description = "활동 API")
 @RequestMapping("/api/v1/activity")
+@RequiredArgsConstructor
 public class ActivityController {
+
+    private final QueryAllActivitiesService queryAllActivitiesService;
+    private final QueryActivityService queryActivityService;
+    private final CreateActivityService createActivityService;
+    private final EditActivityService editActivityService;
+    private final DeleteActivityService deleteActivityService;
 
     @Operation(summary = "전체 활동 조회", description = "서비스에 등록되어 있는 모든 활동 목록과 각 정보를 조회합니다.")
     @ApiResponses({
@@ -22,7 +36,7 @@ public class ActivityController {
     })
     @GetMapping
     public List<ActivityResDto> queryAllActivities() {
-        return null;
+        return queryAllActivitiesService.execute();
     }
 
     @Operation(summary = "활동 단일 조회", description = "활동 정보를 조회합니다.")
@@ -32,7 +46,7 @@ public class ActivityController {
     })
     @GetMapping("/{id}")
     public ActivityResDto queryActivity(@PathVariable Long id) {
-        return null;
+        return queryActivityService.execute(id);
     }
 
     @Operation(summary = "활동 생성", description = "활동을 생성합니다.")
@@ -43,8 +57,8 @@ public class ActivityController {
             @ApiResponse(responseCode = "403", description = "권한 없음")
     })
     @PostMapping("/admin")
-    public ActivityResDto createActivity(@RequestBody ActivityReqDto req) {
-        return null;
+    public ActivityResDto createActivity(@Valid @RequestBody ActivityReqDto req) {
+        return createActivityService.execute(req);
     }
 
     @Operation(summary = "활동 수정", description = "활동 정보를 수정합니다.")
@@ -56,8 +70,8 @@ public class ActivityController {
             @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없음")
     })
     @PatchMapping("/admin/{id}")
-    public ActivityResDto editActivity(@PathVariable Long id, @RequestBody ActivityReqDto req) {
-        return null;
+    public ActivityResDto editActivity(@PathVariable Long id, @Valid @RequestBody ActivityReqDto req) {
+        return editActivityService.execute(id, req);
     }
 
     @Operation(summary = "활동 삭제", description = "활동을 삭제합니다.")
@@ -69,5 +83,6 @@ public class ActivityController {
     })
     @DeleteMapping("/admin/{id}")
     public void deleteActivity(@PathVariable Long id) {
+        deleteActivityService.execute(id);
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/dto/request/ActivityReqDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/dto/request/ActivityReqDto.java
@@ -1,5 +1,6 @@
 package team.themoment.readygsmserver.domain.activity.dto.request;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -16,4 +17,15 @@ public record ActivityReqDto(
         @NotNull LocalDate start,
         @NotNull LocalDate end
 ) {
+    @AssertTrue(message = "신청 시작일은 종료일보다 이전이어야 합니다.")
+    public boolean isStartBeforeEnd() {
+        if (start == null || end == null) return true;
+        return !start.isAfter(end);
+    }
+
+    @AssertTrue(message = "활동일은 신청 시작일 이후여야 합니다.")
+    public boolean isActivityDateAfterStart() {
+        if (activityDate == null || start == null) return true;
+        return !activityDate.isBefore(start);
+    }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/dto/request/ActivityReqDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/dto/request/ActivityReqDto.java
@@ -1,14 +1,19 @@
 package team.themoment.readygsmserver.domain.activity.dto.request;
 
-import java.time.LocalDateTime;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
 
 public record ActivityReqDto(
-        String name,
-        String place,
-        String description,
-        Integer maxApplicant,
-        LocalDateTime activityDate,
-        LocalDateTime start,
-        LocalDateTime end
+        @NotBlank @Size(max = 256) String name,
+        @NotBlank @Size(max = 200) String place,
+        @NotBlank @Size(max = 512) String description,
+        @NotNull @Min(1) Integer maxApplicant,
+        @NotNull LocalDate activityDate,
+        @NotNull LocalDate start,
+        @NotNull LocalDate end
 ) {
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/dto/response/ActivityResDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/dto/response/ActivityResDto.java
@@ -1,6 +1,8 @@
 package team.themoment.readygsmserver.domain.activity.dto.response;
 
-import java.time.LocalDateTime;
+import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
+
+import java.time.LocalDate;
 
 public record ActivityResDto(
         Long id,
@@ -8,8 +10,20 @@ public record ActivityResDto(
         String place,
         String description,
         Integer maxApplicant,
-        LocalDateTime activityDate,
-        LocalDateTime start,
-        LocalDateTime end
+        LocalDate activityDate,
+        LocalDate start,
+        LocalDate end
 ) {
+    public static ActivityResDto from(ActivityJpaEntity entity) {
+        return new ActivityResDto(
+                entity.getId(),
+                entity.getName(),
+                entity.getPlace(),
+                entity.getDescription(),
+                entity.getMaxApplicant(),
+                entity.getActivityDate(),
+                entity.getStart(),
+                entity.getEnd()
+        );
+    }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/entity/ActivityJpaEntity.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/entity/ActivityJpaEntity.java
@@ -2,6 +2,7 @@ package team.themoment.readygsmserver.domain.activity.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import team.themoment.readygsmserver.domain.activity.dto.request.ActivityReqDto;
 
 import java.time.LocalDate;
 
@@ -38,4 +39,14 @@ public class ActivityJpaEntity {
 
     @Column(name = "end", nullable = false)
     private LocalDate end;
+
+    public void update(ActivityReqDto req) {
+        this.name = req.name();
+        this.place = req.place();
+        this.description = req.description();
+        this.maxApplicant = req.maxApplicant();
+        this.activityDate = req.activityDate();
+        this.start = req.start();
+        this.end = req.end();
+    }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/repository/ActivityRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/repository/ActivityRepository.java
@@ -3,7 +3,9 @@ package team.themoment.readygsmserver.domain.activity.repository;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
 
 import java.util.Optional;
@@ -13,4 +15,8 @@ public interface ActivityRepository extends JpaRepository<ActivityJpaEntity, Lon
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT a FROM ActivityJpaEntity a WHERE a.id = :id")
     Optional<ActivityJpaEntity> findByIdWithLock(Long id);
+
+    @Modifying
+    @Query("DELETE FROM ActivityJpaEntity a WHERE a.id = :id")
+    int deleteByActivityId(@Param("id") Long id);
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/service/CreateActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/service/CreateActivityService.java
@@ -1,0 +1,32 @@
+package team.themoment.readygsmserver.domain.activity.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.activity.dto.request.ActivityReqDto;
+import team.themoment.readygsmserver.domain.activity.dto.response.ActivityResDto;
+import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
+import team.themoment.readygsmserver.domain.activity.repository.ActivityRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateActivityService {
+
+    private final ActivityRepository activityRepository;
+
+    public ActivityResDto execute(ActivityReqDto req) {
+        ActivityJpaEntity saved = activityRepository.save(
+                ActivityJpaEntity.builder()
+                        .name(req.name())
+                        .place(req.place())
+                        .description(req.description())
+                        .maxApplicant(req.maxApplicant())
+                        .activityDate(req.activityDate())
+                        .start(req.start())
+                        .end(req.end())
+                        .build()
+        );
+        return ActivityResDto.from(saved);
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/service/DeleteActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/service/DeleteActivityService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
 import team.themoment.readygsmserver.domain.activity.repository.ActivityRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
@@ -16,8 +15,9 @@ public class DeleteActivityService {
     private final ActivityRepository activityRepository;
 
     public void execute(Long id) {
-        ActivityJpaEntity activity = activityRepository.findById(id)
-                .orElseThrow(() -> new ExpectedException("활동을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
-        activityRepository.delete(activity);
+        int deleted = activityRepository.deleteByActivityId(id);
+        if (deleted == 0) {
+            throw new ExpectedException("활동을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/service/DeleteActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/service/DeleteActivityService.java
@@ -1,0 +1,23 @@
+package team.themoment.readygsmserver.domain.activity.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
+import team.themoment.readygsmserver.domain.activity.repository.ActivityRepository;
+import team.themoment.sdk.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteActivityService {
+
+    private final ActivityRepository activityRepository;
+
+    public void execute(Long id) {
+        ActivityJpaEntity activity = activityRepository.findById(id)
+                .orElseThrow(() -> new ExpectedException("활동을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+        activityRepository.delete(activity);
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/service/EditActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/service/EditActivityService.java
@@ -1,0 +1,26 @@
+package team.themoment.readygsmserver.domain.activity.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.activity.dto.request.ActivityReqDto;
+import team.themoment.readygsmserver.domain.activity.dto.response.ActivityResDto;
+import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
+import team.themoment.readygsmserver.domain.activity.repository.ActivityRepository;
+import team.themoment.sdk.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EditActivityService {
+
+    private final ActivityRepository activityRepository;
+
+    public ActivityResDto execute(Long id, ActivityReqDto req) {
+        ActivityJpaEntity activity = activityRepository.findById(id)
+                .orElseThrow(() -> new ExpectedException("활동을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+        activity.update(req);
+        return ActivityResDto.from(activity);
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/service/QueryActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/service/QueryActivityService.java
@@ -1,0 +1,23 @@
+package team.themoment.readygsmserver.domain.activity.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.activity.dto.response.ActivityResDto;
+import team.themoment.readygsmserver.domain.activity.repository.ActivityRepository;
+import team.themoment.sdk.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QueryActivityService {
+
+    private final ActivityRepository activityRepository;
+
+    public ActivityResDto execute(Long id) {
+        return activityRepository.findById(id)
+                .map(ActivityResDto::from)
+                .orElseThrow(() -> new ExpectedException("활동을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/service/QueryAllActivitiesService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/service/QueryAllActivitiesService.java
@@ -1,0 +1,23 @@
+package team.themoment.readygsmserver.domain.activity.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.activity.dto.response.ActivityResDto;
+import team.themoment.readygsmserver.domain.activity.repository.ActivityRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QueryAllActivitiesService {
+
+    private final ActivityRepository activityRepository;
+
+    public List<ActivityResDto> execute() {
+        return activityRepository.findAll().stream()
+                .map(ActivityResDto::from)
+                .toList();
+    }
+}


### PR DESCRIPTION
## 개요

이슈 #30에서 요구된 학과 체험(Activity) 도메인의 CRUD 기능을 구현하였습니다.
기존에 Entity, Repository, Controller 골격과 DTO만 존재하였으나 Service 계층이 부재하고 Controller 메서드가 모두 stub 상태였으며, DTO와 Entity 간 타입 불일치(`LocalDateTime` vs `LocalDate`)도 존재하여 함께 수정하였습니다.

## 변경 사항

### 버그 수정
- `ActivityReqDto`, `ActivityResDto`의 날짜 필드 타입을 `LocalDateTime`에서 Entity와 일치하는 `LocalDate`로 수정하였습니다.

### 기능 추가
- `ActivityReqDto`에 Jakarta Validation 어노테이션(`@NotBlank`, `@Size`, `@NotNull`, `@Min`)을 추가하였습니다.
- `ActivityResDto`에 Entity → DTO 변환을 위한 `from()` 정적 팩토리 메서드를 추가하였습니다.
- `ActivityJpaEntity`에 수정 기능을 위한 `update(ActivityReqDto)` 메서드를 추가하였습니다.
- Command Query Separation 패턴에 따라 서비스 클래스 5개를 구현하였습니다.
  - `QueryAllActivitiesService` : 전체 조회 (`readOnly`)
  - `QueryActivityService` : 단일 조회 (`readOnly`, 없으면 404)
  - `CreateActivityService` : 생성
  - `EditActivityService` : 수정 (없으면 404)
  - `DeleteActivityService` : 삭제 (없으면 404)
- `ActivityController`에 각 서비스를 주입하고 모든 메서드 구현을 완성하였습니다.

## API 명세

| 메서드 | 경로 | 권한 | 설명 |
|--------|------|------|------|
| GET | `/api/v1/activity` | 공개 | 전체 활동 조회 |
| GET | `/api/v1/activity/{id}` | 공개 | 활동 단일 조회 |
| POST | `/api/v1/activity/admin` | ADMIN | 활동 생성 |
| PATCH | `/api/v1/activity/admin/{id}` | ADMIN | 활동 수정 |
| DELETE | `/api/v1/activity/admin/{id}` | ADMIN | 활동 삭제 |

## 관련 이슈

close #30