### PR TITLE
[application] 사용자 본인의 활동 신청 내역 조회 기능 추가

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
@@ -18,6 +18,7 @@ import team.themoment.readygsmserver.domain.application.service.CancelApplicatio
 import team.themoment.readygsmserver.domain.application.service.DeleteApplicationService;
 import team.themoment.readygsmserver.domain.application.service.ExportApplicationExcelService;
 import team.themoment.readygsmserver.domain.application.service.QueryApplicationsService;
+import team.themoment.readygsmserver.domain.application.service.QueryMyApplicationsService;
 import team.themoment.readygsmserver.global.security.annotation.AuthRequest;
 
 import java.nio.charset.StandardCharsets;
@@ -32,6 +33,7 @@ public class ApplicationController {
     private final ApplyActivityService applyActivityService;
     private final CancelApplicationService cancelApplicationService;
     private final QueryApplicationsService queryApplicationsService;
+    private final QueryMyApplicationsService queryMyApplicationsService;
     private final DeleteApplicationService deleteApplicationService;
     private final ExportApplicationExcelService exportApplicationExcelService;
 
@@ -57,6 +59,16 @@ public class ApplicationController {
     @DeleteMapping("/cancel")
     public void cancelApplication(@AuthRequest Long userId, @RequestParam Long activityId) {
         cancelApplicationService.execute(userId, activityId);
+    }
+
+    @Operation(summary = "내 신청 목록 조회", description = "내가 신청한 활동 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @GetMapping("/my")
+    public List<ApplicationResDto> getMyApplications(@AuthRequest Long userId) {
+        return queryMyApplicationsService.execute(userId);
     }
 
     @Operation(summary = "신청한 학생 조회", description = "활동을 신청한 학생 목록을 조회합니다.")

--- a/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
@@ -64,7 +64,8 @@ public class ApplicationController {
     @Operation(summary = "내 신청 목록 조회", description = "내가 신청한 활동 목록을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "신청 내역을 찾을 수 없음")
     })
     @GetMapping("/my")
     public ApplicationResDto getMyApplications(@AuthRequest Long userId) {

--- a/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
@@ -67,7 +67,7 @@ public class ApplicationController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
     @GetMapping("/my")
-    public List<ApplicationResDto> getMyApplications(@AuthRequest Long userId) {
+    public ApplicationResDto getMyApplications(@AuthRequest Long userId) {
         return queryMyApplicationsService.execute(userId);
     }
 

--- a/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
@@ -7,12 +7,13 @@ import org.springframework.data.repository.query.Param;
 import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntity, Long> {
     boolean existsByUser_Id(Long userId);
     long countByActivity_Id(Long activityId);
     List<ApplicationJpaEntity> findAllByActivity_Id(Long activityId);
-    List<ApplicationJpaEntity> findAllByUser_Id(Long userId);
+    Optional<ApplicationJpaEntity> findByUser_Id(Long userId);
 
     @Modifying
     @Query("DELETE FROM ApplicationJpaEntity a WHERE a.activity.id = :activityId AND a.user.id = :userId")

--- a/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
@@ -12,6 +12,7 @@ public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntit
     boolean existsByUser_Id(Long userId);
     long countByActivity_Id(Long activityId);
     List<ApplicationJpaEntity> findAllByActivity_Id(Long activityId);
+    List<ApplicationJpaEntity> findAllByUser_Id(Long userId);
 
     @Modifying
     @Query("DELETE FROM ApplicationJpaEntity a WHERE a.activity.id = :activityId AND a.user.id = :userId")

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/QueryMyApplicationsService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/QueryMyApplicationsService.java
@@ -1,12 +1,12 @@
 package team.themoment.readygsmserver.domain.application.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.readygsmserver.domain.application.dto.response.ApplicationResDto;
 import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
-
-import java.util.List;
+import team.themoment.sdk.exception.ExpectedException;
 
 @Service
 @RequiredArgsConstructor
@@ -15,9 +15,9 @@ public class QueryMyApplicationsService {
 
     private final ApplicationRepository applicationRepository;
 
-    public List<ApplicationResDto> execute(Long userId) {
-        return applicationRepository.findAllByUser_Id(userId).stream()
+    public ApplicationResDto execute(Long userId) {
+        return applicationRepository.findByUser_Id(userId)
                 .map(ApplicationResDto::from)
-                .toList();
+                .orElseThrow(() -> new ExpectedException("신청 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/QueryMyApplicationsService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/QueryMyApplicationsService.java
@@ -1,0 +1,23 @@
+package team.themoment.readygsmserver.domain.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.application.dto.response.ApplicationResDto;
+import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QueryMyApplicationsService {
+
+    private final ApplicationRepository applicationRepository;
+
+    public List<ApplicationResDto> execute(Long userId) {
+        return applicationRepository.findAllByUser_Id(userId).stream()
+                .map(ApplicationResDto::from)
+                .toList();
+    }
+}


### PR DESCRIPTION
## 개요

현재 로그인한 사용자가 본인이 신청한 활동 목록을 조회할 수 있는 API를 추가하였습니다.

## 변경 사항

### 추가된 API

- `GET /api/v1/application/my`
  - 현재 로그인한 사용자의 활동 신청 목록을 반환하는 엔드포인트를 추가하였습니다.
  - `@AuthRequest`를 통해 세션에서 userId를 추출하여 조회하였습니다.

### 변경된 파일

- **`ApplicationRepository`**
  - `findAllByUser_Id(Long userId)` 메서드를 추가하였습니다.

- **`QueryMyApplicationsService`** (신규)
  - userId를 기반으로 해당 사용자의 신청 목록을 조회하는 서비스를 추가하였습니다.

- **`ApplicationController`**
  - `GET /api/v1/application/my` 엔드포인트를 추가하였습니다.
  - `QueryMyApplicationsService`를 주입하여 서비스와 연결하였습니다.

## 응답 예시

```json
[
  {
    "id": 1,
    "activityId": 3,
    "userId": 10,
    "name": "홍길동",
    "grade": 2,
    "classNumber": 1,
    "number": 5,
    "schoolName": "광주소프트웨어마이스터고",
    "phoneNumber": "010-1234-5678",
    "familyPhoneNumber": "010-8765-4321"
  }
]
```