### PR TITLE
[activity] 신청 기간을 LocalDateTime으로 변경하고 활동 시각 필드 추가

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/activity/dto/request/ActivityReqDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/dto/request/ActivityReqDto.java
@@ -7,6 +7,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 public record ActivityReqDto(
         @NotBlank @Size(max = 256) String name,
@@ -14,18 +16,26 @@ public record ActivityReqDto(
         @NotBlank @Size(max = 512) String description,
         @NotNull @Min(1) Integer maxApplicant,
         @NotNull LocalDate activityDate,
-        @NotNull LocalDate start,
-        @NotNull LocalDate end
+        @NotNull LocalDateTime registrationStartAt,
+        @NotNull LocalDateTime registrationEndAt,
+        @NotNull LocalTime activityStartTime,
+        @NotNull LocalTime activityEndTime
 ) {
-    @AssertTrue(message = "신청 시작일은 종료일보다 이전이어야 합니다.")
-    public boolean isStartBeforeEnd() {
-        if (start == null || end == null) return true;
-        return !start.isAfter(end);
+    @AssertTrue(message = "신청 시작 시각은 종료 시각보다 이전이어야 합니다.")
+    public boolean isRegistrationStartBeforeEnd() {
+        if (registrationStartAt == null || registrationEndAt == null) return true;
+        return !registrationStartAt.isAfter(registrationEndAt);
     }
 
-    @AssertTrue(message = "활동일은 신청 시작일 이후여야 합니다.")
-    public boolean isActivityDateAfterStart() {
-        if (activityDate == null || start == null) return true;
-        return !activityDate.isBefore(start);
+    @AssertTrue(message = "활동 시작 시각은 종료 시각보다 이전이어야 합니다.")
+    public boolean isActivityStartBeforeEnd() {
+        if (activityStartTime == null || activityEndTime == null) return true;
+        return activityStartTime.isBefore(activityEndTime);
+    }
+
+    @AssertTrue(message = "신청 마감은 활동 당일 또는 그 이전이어야 합니다.")
+    public boolean isRegistrationEndBeforeActivity() {
+        if (registrationEndAt == null || activityDate == null) return true;
+        return !registrationEndAt.toLocalDate().isAfter(activityDate);
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/dto/request/ActivityReqDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/dto/request/ActivityReqDto.java
@@ -24,7 +24,7 @@ public record ActivityReqDto(
     @AssertTrue(message = "신청 시작 시각은 종료 시각보다 이전이어야 합니다.")
     public boolean isRegistrationStartBeforeEnd() {
         if (registrationStartAt == null || registrationEndAt == null) return true;
-        return !registrationStartAt.isAfter(registrationEndAt);
+        return registrationStartAt.isBefore(registrationEndAt);
     }
 
     @AssertTrue(message = "활동 시작 시각은 종료 시각보다 이전이어야 합니다.")
@@ -33,9 +33,9 @@ public record ActivityReqDto(
         return activityStartTime.isBefore(activityEndTime);
     }
 
-    @AssertTrue(message = "신청 마감은 활동 당일 또는 그 이전이어야 합니다.")
+    @AssertTrue(message = "신청 마감은 활동 시작 시각보다 이전이어야 합니다.")
     public boolean isRegistrationEndBeforeActivity() {
-        if (registrationEndAt == null || activityDate == null) return true;
-        return !registrationEndAt.toLocalDate().isAfter(activityDate);
+        if (registrationEndAt == null || activityDate == null || activityStartTime == null) return true;
+        return registrationEndAt.isBefore(LocalDateTime.of(activityDate, activityStartTime));
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/dto/response/ActivityResDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/dto/response/ActivityResDto.java
@@ -3,6 +3,8 @@ package team.themoment.readygsmserver.domain.activity.dto.response;
 import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 public record ActivityResDto(
         Long id,
@@ -11,8 +13,10 @@ public record ActivityResDto(
         String description,
         Integer maxApplicant,
         LocalDate activityDate,
-        LocalDate start,
-        LocalDate end
+        LocalDateTime registrationStartAt,
+        LocalDateTime registrationEndAt,
+        LocalTime activityStartTime,
+        LocalTime activityEndTime
 ) {
     public static ActivityResDto from(ActivityJpaEntity entity) {
         return new ActivityResDto(
@@ -22,8 +26,10 @@ public record ActivityResDto(
                 entity.getDescription(),
                 entity.getMaxApplicant(),
                 entity.getActivityDate(),
-                entity.getStart(),
-                entity.getEnd()
+                entity.getRegistrationStartAt(),
+                entity.getRegistrationEndAt(),
+                entity.getActivityStartTime(),
+                entity.getActivityEndTime()
         );
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/entity/ActivityJpaEntity.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/entity/ActivityJpaEntity.java
@@ -5,6 +5,8 @@ import lombok.*;
 import team.themoment.readygsmserver.domain.activity.dto.request.ActivityReqDto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
 @Table(name = "tb_activity")
@@ -34,11 +36,17 @@ public class ActivityJpaEntity {
     @Column(name = "activity_date", nullable = false)
     private LocalDate activityDate;
 
-    @Column(name = "start", nullable = false)
-    private LocalDate start;
+    @Column(name = "registration_start_at", nullable = false)
+    private LocalDateTime registrationStartAt;
 
-    @Column(name = "end", nullable = false)
-    private LocalDate end;
+    @Column(name = "registration_end_at", nullable = false)
+    private LocalDateTime registrationEndAt;
+
+    @Column(name = "activity_start_time", nullable = false)
+    private LocalTime activityStartTime;
+
+    @Column(name = "activity_end_time", nullable = false)
+    private LocalTime activityEndTime;
 
     public void update(ActivityReqDto req) {
         this.name = req.name();
@@ -46,7 +54,9 @@ public class ActivityJpaEntity {
         this.description = req.description();
         this.maxApplicant = req.maxApplicant();
         this.activityDate = req.activityDate();
-        this.start = req.start();
-        this.end = req.end();
+        this.registrationStartAt = req.registrationStartAt();
+        this.registrationEndAt = req.registrationEndAt();
+        this.activityStartTime = req.activityStartTime();
+        this.activityEndTime = req.activityEndTime();
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/activity/service/CreateActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/activity/service/CreateActivityService.java
@@ -23,8 +23,10 @@ public class CreateActivityService {
                         .description(req.description())
                         .maxApplicant(req.maxApplicant())
                         .activityDate(req.activityDate())
-                        .start(req.start())
-                        .end(req.end())
+                        .registrationStartAt(req.registrationStartAt())
+                        .registrationEndAt(req.registrationEndAt())
+                        .activityStartTime(req.activityStartTime())
+                        .activityEndTime(req.activityEndTime())
                         .build()
         );
         return ActivityResDto.from(saved);


### PR DESCRIPTION
## 개요

학과 체험(Activity) 도메인의 신청 기간 및 활동 시간 표현을 보강하였습니다. 기존 `start`, `end` 필드는 `LocalDate` 타입으로 일 단위 신청 기간만 표현 가능하였고, 활동의 실제 진행 시간(시/분)을 표현할 수 있는 필드가 부재하였기에 이를 개선하였습니다.

## 변경 사항

### 필드 재설계

| 분류 | 기존 | 변경 후 | 타입 |
|---|---|---|---|
| 신청 시작 | `start` | `registrationStartAt` | `LocalDate` → `LocalDateTime` |
| 신청 종료 | `end` | `registrationEndAt` | `LocalDate` → `LocalDateTime` |
| 활동 날짜 | `activityDate` | `activityDate` (유지) | `LocalDate` |
| 활동 시작 시각 | (없음) | `activityStartTime` (신규) | `LocalTime` |
| 활동 종료 시각 | (없음) | `activityEndTime` (신규) | `LocalTime` |

- 신청 기간은 분 단위 마감 시각을 표현할 수 있도록 `LocalDateTime`으로 변경하였습니다.
- 활동 시각은 단일 날짜 활동만 존재한다는 도메인 가정에 따라 `LocalDate + LocalTime` 분리 모델을 채택하여 데이터 중복 없이 사용자의 입력 의도(날짜 picker + 시간 picker)에 부합하도록 설계하였습니다.

### 검증 로직 (`@AssertTrue`)

기존 검증 로직을 새 필드 구조에 맞게 다음과 같이 재작성하였습니다.

- `isRegistrationStartBeforeEnd`: 신청 시작 시각이 종료 시각보다 이전이어야 합니다.
- `isActivityStartBeforeEnd`: 활동 시작 시각이 종료 시각보다 이전이어야 합니다 (단일 날짜 가정에 따라 strict less-than).
- `isRegistrationEndBeforeActivity`: 신청 마감 일자가 활동 당일 또는 그 이전이어야 합니다.

### 수정된 파일

- `ActivityJpaEntity`: 필드 선언 및 `update` 메서드 매핑을 갱신하였습니다.
- `ActivityReqDto`: 요청 필드와 검증 로직을 새 구조로 재작성하였습니다.
- `ActivityResDto`: 응답 필드와 `from` 매퍼를 갱신하였습니다.
- `CreateActivityService`: 빌더 호출부에 새 필드를 매핑하도록 수정하였습니다.

## 영향도

- `ActivityController`, `QueryActivityService`, `QueryAllActivitiesService`, `DeleteActivityService`, `ActivityRepository`는 DTO/엔티티만 거치므로 코드 변경이 발생하지 않았습니다.
- `Application` 도메인은 `ActivityRepository.countByActivity_Id`만 사용하므로 영향이 없습니다.
- Activity 관련 테스트 코드는 존재하지 않습니다.
- 별도의 schema 또는 마이그레이션 파일이 없어 JPA가 자동으로 새 스키마를 생성합니다.

## 테스트 방법

1. `./gradlew build`로 컴파일이 성공하는지 확인하였습니다.
2. `./gradlew bootRun` 실행 후 다음을 검증해 주세요.
   - `POST /api/v1/activity/admin`: 새 필드를 포함한 요청이 성공하며 응답에 모든 새 필드가 포함되는지
   - 검증 실패 케이스(`registrationStartAt > registrationEndAt`, `activityStartTime ≥ activityEndTime`, `registrationEndAt`가 `activityDate` 이후) 각각이 400 응답을 반환하는지
   - `GET /api/v1/activity`, `GET /api/v1/activity/{id}` 응답 구조에 새 필드가 노출되는지
   - `PATCH /api/v1/activity/admin/{id}`로 수정이 정상 동작하는지

## 후속 작업

- 프론트엔드에 API 스키마 변경 사항(필드명/타입)을 공유하여야 합니다.
- 운영 환경에 기존 데이터가 존재한다면 별도의 데이터 마이그레이션 스크립트가 필요합니다. 현재는 `data.sql` 시드 데이터만 존재하여 본 PR 범위에서는 별도 작업이 필요하지 않았습니다.
