### PR TITLE
[global] Vercel 프론트 배포 URL OAuth 리다이렉트 URI 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,6 +59,7 @@ oauth2:
     - "http://localhost:3000/oauth/callback"
     - "https://kimtaeeun.site/ready-gsm/oauth/callback"
     - "https://www.readygsm.kr/oauth/callback"
+    - "https://readygsm-client.vercel.app/oauth/callback"
 
 sdk:
   logging:


### PR DESCRIPTION
## 개요

프론트엔드가 Vercel(`https://readygsm-client.vercel.app`)에 배포됨에 따라, 해당 URL의 OAuth 콜백 경로를 `allowed-redirect-uris`에 추가하였습니다.

## 변경 사항

### `application.yml`

- `oauth2.allowed-redirect-uris`에 `https://readygsm-client.vercel.app/oauth/callback` 추가

## 사전 작업

- Google Cloud Console 승인된 리디렉션 URI에 동일 URL 등록 완료
- Kakao Developers 카카오 로그인 리다이렉트 URI에 동일 URL 등록 완료