### PR TITLE
[ci/cd] Production CD 트리거 브랜치를 main에서 master로 변경

### DIFF
--- a/.github/workflows/readygsm-prod-cd.yml
+++ b/.github/workflows/readygsm-prod-cd.yml
@@ -3,7 +3,7 @@ name: Production CD
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## 개요

Production CD 워크플로우의 트리거 브랜치가 `main`으로 설정되어 있었으나, 해당 레포지토리의 기본 브랜치는 `master`입니다. 이로 인해 `master` 브랜치에 머지해도 워크플로우가 실행되지 않는 문제를 수정하였습니다.

## 변경 사항

- `.github/workflows/readygsm-prod-cd.yml`: 트리거 브랜치 `main` → `master` 변경