### PR TITLE
[global] HTTPS 설정 적용 및 HTTP 리다이렉트 추가

### DIFF
--- a/deploy/compose.prod.yml
+++ b/deploy/compose.prod.yml
@@ -7,7 +7,7 @@ services:
       - "443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./nginx/certs:/etc/nginx/certs:ro
+      - /etc/letsencrypt:/etc/nginx/certs:ro
     depends_on:
       - app
     restart: always

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -11,7 +11,10 @@ server {
     ssl_certificate     /etc/nginx/certs/live/ready.hellogsm.kr/fullchain.pem;
     ssl_certificate_key /etc/nginx/certs/live/ready.hellogsm.kr/privkey.pem;
     ssl_protocols       TLSv1.2 TLSv1.3;
-    ssl_ciphers         HIGH:!aNULL:!MD5;
+    ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
 
     location / {
         proxy_pass         http://app:8080;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,33 +1,23 @@
 server {
     listen 80;
     server_name ready.hellogsm.kr;
-    # HTTPS 전환 후 아래 주석 해제
-    # return 301 https://$host$request_uri;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name ready.hellogsm.kr;
+
+    ssl_certificate     /etc/nginx/certs/live/ready.hellogsm.kr/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/live/ready.hellogsm.kr/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
 
     location / {
         proxy_pass         http://app:8080;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   X-Forwarded-Proto https;
     }
 }
-
-# Certbot으로 ready.hellogsm.kr 인증서 발급 후 아래 블록 주석 해제
-# server {
-#     listen 443 ssl;
-#     server_name ready.hellogsm.kr;
-#
-#     ssl_certificate     /etc/nginx/certs/live/ready.hellogsm.kr/fullchain.pem;
-#     ssl_certificate_key /etc/nginx/certs/live/ready.hellogsm.kr/privkey.pem;
-#     ssl_protocols       TLSv1.2 TLSv1.3;
-#     ssl_ciphers         HIGH:!aNULL:!MD5;
-#
-#     location / {
-#         proxy_pass         http://app:8080;
-#         proxy_set_header   Host              $host;
-#         proxy_set_header   X-Real-IP         $remote_addr;
-#         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-#         proxy_set_header   X-Forwarded-Proto https;
-#     }
-# }


### PR DESCRIPTION
## 개요

EC2에서 Certbot으로 `ready.hellogsm.kr` SSL 인증서 발급 후 HTTPS를 적용하였습니다.

## 변경 사항

### `docker/nginx.conf`

- HTTP(80) → HTTPS(443) 리다이렉트 적용
- HTTPS 서버 블록 주석 해제 및 SSL 인증서 경로 설정

### `deploy/compose.prod.yml`

- nginx certs 볼륨 경로를 `./nginx/certs` → `/etc/letsencrypt`로 변경
  - EC2 호스트의 Certbot 인증서 디렉토리를 직접 마운트

## 사전 작업

- EC2에서 `certbot certonly --standalone -d ready.hellogsm.kr` 인증서 발급 완료
- 인증서 위치: `/etc/letsencrypt/live/ready.hellogsm.kr/`
- 만료일: 2026-09-05