### PR TITLE
[global] CORS 설정 추가 및 SameSite 쿠키 정책 수정

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/global/config/CorsProperties.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/CorsProperties.java
@@ -1,0 +1,14 @@
+package team.themoment.readygsmserver.global.config;
+
+import jakarta.validation.constraints.NotNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+
+@Validated
+@ConfigurationProperties(prefix = "cors")
+public record CorsProperties(
+        @NotNull List<String> allowedOrigins
+) {
+}

--- a/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(cors -> {})
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
@@ -72,7 +73,8 @@ public class SecurityConfig {
         DefaultCookieSerializer serializer = new DefaultCookieSerializer();
         serializer.setCookieName("SESSION");
         serializer.setUseHttpOnlyCookie(true);
-        serializer.setSameSite("Lax");
+        serializer.setSameSite("None");
+        serializer.setUseSecureCookie(true);
         serializer.setCookiePath("/");
         return serializer;
     }

--- a/src/main/java/team/themoment/readygsmserver/global/config/WebMvcConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/WebMvcConfig.java
@@ -5,38 +5,21 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import team.themoment.readygsmserver.global.security.oauth2.OAuth2Properties;
 import team.themoment.readygsmserver.global.security.resolver.AuthenticationArgumentResolver;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 
-    private final OAuth2Properties oauth2Properties;
+    private final CorsProperties corsProperties;
     private final AuthenticationArgumentResolver authenticationArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        String[] allowedOrigins = oauth2Properties.allowedRedirectUris().stream()
-                .map(uri -> {
-                    try {
-                        URI parsed = new URI(uri);
-                        int port = parsed.getPort();
-                        return parsed.getScheme() + "://" + parsed.getHost() +
-                               (port != -1 ? ":" + port : "");
-                    } catch (URISyntaxException e) {
-                        throw new IllegalStateException("Invalid redirect URI in config: " + uri, e);
-                    }
-                })
-                .distinct()
-                .toArray(String[]::new);
-
         registry.addMapping("/api/**")
-                .allowedOrigins(allowedOrigins)
+                .allowedOrigins(corsProperties.allowedOrigins().toArray(String[]::new))
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/src/main/java/team/themoment/readygsmserver/global/config/WebMvcConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/WebMvcConfig.java
@@ -5,28 +5,38 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import team.themoment.readygsmserver.global.security.oauth2.OAuth2Properties;
 import team.themoment.readygsmserver.global.security.resolver.AuthenticationArgumentResolver;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 
-    private static final String[] ALLOWED_ORIGINS = {
-            "http://localhost:3000",
-            "https://kimtaeeun.site",
-            "https://www.readygsm.kr",
-            "https://readygsm-client.vercel.app",
-            "https://ready.hellogsm.kr"
-    };
-
+    private final OAuth2Properties oauth2Properties;
     private final AuthenticationArgumentResolver authenticationArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
+        String[] allowedOrigins = oauth2Properties.allowedRedirectUris().stream()
+                .map(uri -> {
+                    try {
+                        URI parsed = new URI(uri);
+                        int port = parsed.getPort();
+                        return parsed.getScheme() + "://" + parsed.getHost() +
+                               (port != -1 ? ":" + port : "");
+                    } catch (URISyntaxException e) {
+                        throw new IllegalStateException("Invalid redirect URI in config: " + uri, e);
+                    }
+                })
+                .distinct()
+                .toArray(String[]::new);
+
         registry.addMapping("/api/**")
-                .allowedOrigins(ALLOWED_ORIGINS)
+                .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/src/main/java/team/themoment/readygsmserver/global/config/WebMvcConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/WebMvcConfig.java
@@ -3,6 +3,7 @@ package team.themoment.readygsmserver.global.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import team.themoment.readygsmserver.global.security.resolver.AuthenticationArgumentResolver;
 
@@ -12,7 +13,25 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 
+    private static final String[] ALLOWED_ORIGINS = {
+            "http://localhost:3000",
+            "https://kimtaeeun.site",
+            "https://www.readygsm.kr",
+            "https://readygsm-client.vercel.app",
+            "https://ready.hellogsm.kr"
+    };
+
     private final AuthenticationArgumentResolver authenticationArgumentResolver;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins(ALLOWED_ORIGINS)
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,14 @@ kakao:
     client-id: ${KAKAO_CLIENT_ID}
     client-secret: ${KAKAO_CLIENT_SECRET}
 
+cors:
+  allowed-origins:
+    - "http://localhost:3000"
+    - "https://kimtaeeun.site"
+    - "https://www.readygsm.kr"
+    - "https://readygsm-client.vercel.app"
+    - "https://ready.hellogsm.kr"
+
 oauth2:
   success-redirect-url: ${OAUTH2_SUCCESS_REDIRECT_URL:/}
   failure-redirect-url: ${OAUTH2_FAILURE_REDIRECT_URL:/}


### PR DESCRIPTION
## 개요

프론트엔드(`readygsm-client.vercel.app` 등)에서 `ready.hellogsm.kr`로 cross-origin 요청 시 로그인이 불가능한 문제를 수정하였습니다.

CORS가 설정되어 있지 않아 브라우저의 preflight(OPTIONS) 요청이 차단되고, Spring Security가 403을 반환하고 있었습니다. 또한 `SameSite=Lax` 정책으로 인해 로그인 후 cross-origin AJAX 요청 시 세션 쿠키가 전송되지 않는 문제도 함께 수정하였습니다.

## 변경 사항

### `global/config/WebMvcConfig.java`

- `addCorsMappings` 추가
  - 허용 origin: `localhost:3000`, `kimtaeeun.site`, `www.readygsm.kr`, `readygsm-client.vercel.app`, `ready.hellogsm.kr`
  - `allowCredentials(true)` 설정 — 세션 쿠키 포함 요청 허용
  - 허용 메서드: GET, POST, PUT, DELETE, PATCH, OPTIONS

### `global/config/SecurityConfig.java`

- `.cors(cors -> {})` 추가 — Spring Security가 WebMvcConfig의 CORS 설정을 따르도록 연결 (없으면 Security 레이어에서 OPTIONS 요청 차단)
- `SameSite=Lax` → `SameSite=None; Secure=true` 변경
  - `SameSite=Lax`는 cross-origin AJAX 요청에서 쿠키를 전송하지 않음
  - `SameSite=None`은 `Secure=true`와 함께 사용해야 하며, HTTPS 환경이므로 적용 가능