### PR TITLE
[global] Spring Session Redis 인증 수정

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/SecurityConfig.java
@@ -11,14 +11,12 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.context.SecurityContextRepository;
-import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.session.web.http.CookieSerializer;
 import org.springframework.session.web.http.DefaultCookieSerializer;
 import team.themoment.readygsmserver.domain.user.entity.constant.Role;
 
 @Configuration
 @EnableWebSecurity
-@EnableRedisHttpSession
 public class SecurityConfig {
 
     private static final String[] PUBLIC_PATHS = {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,6 @@ spring:
       database: 1
 
   session:
-    store-type: redis
     redis:
       flush-mode: immediate
       save-mode: on-set-attribute

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,7 @@ spring:
       database: 1
 
   session:
+    store-type: redis
     redis:
       flush-mode: immediate
       save-mode: on-set-attribute


### PR DESCRIPTION
## 개요

로그인 후 `/api/v1/user/me` 등 인증이 필요한 API 호출 시 세션이 Redis에 존재함에도 403이 반환되는 문제를 수정하였습니다.

`@EnableRedisHttpSession`이 Spring Boot 4.x 환경에서 `SessionRepositoryFilter`를 Spring Security 필터보다 늦게 등록하여, Spring Security가 Redis 세션 대신 Tomcat 네이티브 세션(`JSESSIONID`)을 참조하는 것이 원인이었습니다. 결과적으로 Redis에 저장된 `SecurityContext`를 읽지 못해 모든 요청이 미인증으로 처리됐습니다.

## 변경 사항

### `global/config/SecurityConfig.java`

- `@EnableRedisHttpSession` 제거
  - 해당 어노테이션이 `SessionRepositoryFilter`를 Spring Security 이후 순서로 등록하여 Redis 세션을 무시하는 문제 유발
  - Spring Boot 자동 구성(`spring.session.store-type: redis`)으로 전환 시 필터가 올바른 순서(`Integer.MIN_VALUE + 50`)로 등록됨

### `src/main/resources/application.yml`

- `spring.session.store-type: redis` 추가
  - Spring Boot가 `SessionRepositoryFilter`를 자동으로 등록하도록 명시