### PR TITLE
[global] SessionRepositoryFilter 순서를 Spring Security보다 앞으로 명시 설정

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/global/config/HttpSessionConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/HttpSessionConfig.java
@@ -1,0 +1,26 @@
+package team.themoment.readygsmserver.global.config;
+
+import jakarta.servlet.DispatcherType;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.session.web.http.SessionRepositoryFilter;
+
+import java.util.EnumSet;
+
+@Configuration
+@EnableRedisHttpSession
+public class HttpSessionConfig {
+
+    @Bean
+    public FilterRegistrationBean<SessionRepositoryFilter<?>> springSessionRepositoryFilterRegistration(
+            SessionRepositoryFilter<?> springSessionRepositoryFilter) {
+        FilterRegistrationBean<SessionRepositoryFilter<?>> registration =
+                new FilterRegistrationBean<>(springSessionRepositoryFilter);
+        registration.setOrder(Integer.MIN_VALUE + 50);
+        registration.setDispatcherTypes(EnumSet.of(
+                DispatcherType.REQUEST, DispatcherType.ERROR, DispatcherType.ASYNC));
+        return registration;
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/global/config/HttpSessionConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/HttpSessionConfig.java
@@ -13,12 +13,14 @@ import java.util.EnumSet;
 @EnableRedisHttpSession
 public class HttpSessionConfig {
 
+    private static final int SESSION_FILTER_ORDER = Integer.MIN_VALUE + 50;
+
     @Bean
     public FilterRegistrationBean<SessionRepositoryFilter<?>> springSessionRepositoryFilterRegistration(
             SessionRepositoryFilter<?> springSessionRepositoryFilter) {
         FilterRegistrationBean<SessionRepositoryFilter<?>> registration =
                 new FilterRegistrationBean<>(springSessionRepositoryFilter);
-        registration.setOrder(Integer.MIN_VALUE + 50);
+        registration.setOrder(SESSION_FILTER_ORDER);
         registration.setDispatcherTypes(EnumSet.of(
                 DispatcherType.REQUEST, DispatcherType.ERROR, DispatcherType.ASYNC));
         return registration;


### PR DESCRIPTION
## 개요

로그인 후 세션 쿠키(`SESSION`)가 정상 발급됨에도 이후 인증 API 호출 시 403이 반환되는 문제를 수정하였습니다.

`@EnableRedisHttpSession`만 사용할 경우 Spring Boot가 `SessionRepositoryFilter`를 `LOWEST_PRECEDENCE`로 자동 등록하여 Spring Security(`-100`)보다 **늦게** 실행됩니다. 이로 인해 Spring Security는 Redis 세션 대신 Tomcat 네이티브 세션을 참조하게 되어 인증 정보를 읽지 못하고 403을 반환합니다.

## 변경 사항

### `global/config/HttpSessionConfig.java` (신규)

- `@EnableRedisHttpSession`을 별도 설정 클래스로 분리
- `FilterRegistrationBean`으로 `SessionRepositoryFilter` 순서를 `Integer.MIN_VALUE + 50`으로 명시
  - Spring Security 필터(`-100`)보다 훨씬 앞서 실행되어 요청이 Spring Security에 도달하기 전에 Redis 세션을 로드함
  - `DispatcherType.REQUEST / ERROR / ASYNC` 모두 적용

## 필터 실행 순서 (수정 후)

| 순서 | 필터 |
|---|---|
| `Integer.MIN_VALUE + 50` | `SessionRepositoryFilter` ← Redis 세션 로드 |
| `-100` | Spring Security ← 이미 로드된 세션에서 인증 정보 읽음 |