### PR TITLE
[user] GET /api/v1/user/me 내 정보 조회 API 추가

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/user/controller/UserController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/controller/UserController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team.themoment.readygsmserver.domain.user.dto.response.UserResDto;
-import team.themoment.readygsmserver.domain.user.service.UserService;
+import team.themoment.readygsmserver.domain.user.service.QueryUserService;
 
 @RestController
 @Tag(name = "User", description = "유저 API")
@@ -19,7 +19,7 @@ import team.themoment.readygsmserver.domain.user.service.UserService;
 @RequiredArgsConstructor
 public class UserController {
 
-    private final UserService userService;
+    private final QueryUserService queryUserService;
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 유저의 정보를 반환합니다.")
     @ApiResponses({
@@ -27,7 +27,7 @@ public class UserController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
     @GetMapping("/me")
-    public UserResDto getMe(@AuthenticationPrincipal OAuth2User user) {
-        return userService.getMe(user);
+    public UserResDto queryMe(@AuthenticationPrincipal OAuth2User user) {
+        return queryUserService.execute(user);
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/user/controller/UserController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/controller/UserController.java
@@ -1,0 +1,33 @@
+package team.themoment.readygsmserver.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team.themoment.readygsmserver.domain.user.dto.response.UserResDto;
+import team.themoment.readygsmserver.domain.user.service.UserService;
+
+@RestController
+@Tag(name = "User", description = "유저 API")
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 유저의 정보를 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @GetMapping("/me")
+    public UserResDto getMe(@AuthenticationPrincipal OAuth2User user) {
+        return userService.getMe(user);
+    }
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/user/service/QueryUserService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/service/QueryUserService.java
@@ -5,9 +5,9 @@ import org.springframework.stereotype.Service;
 import team.themoment.readygsmserver.domain.user.dto.response.UserResDto;
 
 @Service
-public class UserService {
+public class QueryUserService {
 
-    public UserResDto getMe(OAuth2User user) {
+    public UserResDto execute(OAuth2User user) {
         Long id = ((Number) user.getAttribute("id")).longValue();
         String email = user.getAttribute("email");
         String role = user.getAttribute("role");

--- a/src/main/java/team/themoment/readygsmserver/domain/user/service/UserService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/service/UserService.java
@@ -1,0 +1,16 @@
+package team.themoment.readygsmserver.domain.user.service;
+
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import team.themoment.readygsmserver.domain.user.dto.response.UserResDto;
+
+@Service
+public class UserService {
+
+    public UserResDto getMe(OAuth2User user) {
+        Long id = ((Number) user.getAttribute("id")).longValue();
+        String email = user.getAttribute("email");
+        String role = user.getAttribute("role");
+        return new UserResDto(id, email, role);
+    }
+}


### PR DESCRIPTION
## 개요

`GET /api/v1/user/me` 엔드포인트가 백엔드에 존재하지 않아 프론트엔드 요청이 404로 반환되는 문제를 수정합니다.

`feature/user-me-api` 브랜치에 구현되어 있던 `UserController`와 `UserService`가 develop/master에 한 번도 머지되지 않아 프로덕션에서 해당 API가 없는 상태였습니다.

## 변경 사항

### `domain/user/controller/UserController.java` (신규)

- `GET /api/v1/user/me` 엔드포인트 추가
- `@AuthenticationPrincipal OAuth2User`로 Spring Security 세션에서 사용자 정보를 가져옴

### `domain/user/service/UserService.java` (신규)

- `OAuth2User` attributes(`id`, `email`, `role`)를 읽어 `UserResDto`로 반환
- DB 조회 없이 세션에 저장된 인증 정보를 직접 활용