### PR TITLE
[user] 신규 가입 시 초기 권한을 UNAUTHENTICATED에서 USER로 수정

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/user/entity/UserJpaEntity.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/user/entity/UserJpaEntity.java
@@ -39,7 +39,7 @@ public class UserJpaEntity {
         return UserJpaEntity.builder()
                 .email(email)
                 .authReferrerType(authReferrerType)
-                .role(Role.UNAUTHENTICATED)
+                .role(Role.USER)
                 .lastLoginTime(LocalDateTime.now())
                 .build();
     }


### PR DESCRIPTION
## 개요

OAuth2 로그인으로 신규 가입 시 사용자 권한이 `UNAUTHENTICATED`로 설정되어, 로그인 후에도 프론트엔드에서 미인증 상태(`로그인이 필요한 기능입니다`)로 처리되는 버그를 수정합니다.

`buildMemberWithOauthInfo()`에서 `Role.UNAUTHENTICATED`를 명시적으로 세팅하던 것이 원인입니다. `@Builder.Default`로 `Role.USER`가 지정되어 있어도 명시적 값이 우선되어 신규 사용자가 항상 `UNAUTHENTICATED`로 생성되었습니다.

## 변경 사항

### `domain/user/entity/UserJpaEntity.java`

- `buildMemberWithOauthInfo()`에서 초기 권한을 `Role.UNAUTHENTICATED` → `Role.USER`로 수정
  - 신규 가입 사용자가 로그인 직후 정상 권한으로 서비스를 이용할 수 있도록 변경