### PR TITLE
[globa]: 백엔드 도메인을 api.ready.hellogsm.kr로 변경

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,15 +1,15 @@
 server {
     listen 80;
-    server_name ready.hellogsm.kr;
+    server_name api.ready.hellogsm.kr;
     return 301 https://$host$request_uri;
 }
 
 server {
     listen 443 ssl;
-    server_name ready.hellogsm.kr;
+    server_name api.ready.hellogsm.kr;
 
-    ssl_certificate     /etc/nginx/certs/live/ready.hellogsm.kr/fullchain.pem;
-    ssl_certificate_key /etc/nginx/certs/live/ready.hellogsm.kr/privkey.pem;
+    ssl_certificate     /etc/nginx/certs/live/api.ready.hellogsm.kr/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/live/api.ready.hellogsm.kr/privkey.pem;
     ssl_protocols       TLSv1.2 TLSv1.3;
     ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -240,7 +240,7 @@ new aws.ecr.LifecyclePolicy(`${prefix}-app-lifecycle`, {
     }),
 });
 
-// ── Route 53 A 레코드 (ready.hellogsm.kr) ────────────────
+// ── Route 53 A 레코드 (api.ready.hellogsm.kr) ────────────────
 const hostedZone = aws.route53.getZone({
     name: "hellogsm.kr",
     privateZone: false,
@@ -248,7 +248,7 @@ const hostedZone = aws.route53.getZone({
 
 new aws.route53.Record(`${prefix}-dns`, {
     zoneId: hostedZone.then((hz) => hz.zoneId),
-    name: "ready.hellogsm.kr",
+    name: "api.ready.hellogsm.kr",
     type: "A",
     ttl: 300,
     records: [eip.publicIp],
@@ -260,4 +260,4 @@ export const ec2InstanceId = ec2.id;
 export const ec2PublicIp = eip.publicIp;
 export const ecrRepositoryUrl = ecrRepo.repositoryUrl;
 export const ecrRepositoryName = ecrRepo.name;
-export const appDomain = "ready.hellogsm.kr";
+export const appDomain = "api.ready.hellogsm.kr";


### PR DESCRIPTION
## 개요

프론트엔드 배포 도메인이 `www.ready.hellogsm.kr`로 변경됨에 따라, 기존 백엔드 도메인(`ready.hellogsm.kr`)이 Vercel CNAME으로 덮여 307 무한 리다이렉트가 발생했습니다.

백엔드 전용 서브도메인 `api.ready.hellogsm.kr`을 분리하여 문제를 해결합니다.

## 변경 사항

### `docker/nginx.conf`

- `server_name` 및 SSL 인증서 경로를 `ready.hellogsm.kr` → `api.ready.hellogsm.kr`로 변경

### `infra/index.ts`

- Route53 A 레코드 이름을 `ready.hellogsm.kr` → `api.ready.hellogsm.kr`로 변경
- `appDomain` 출력값 동일하게 변경