### PR TITLE
[ci/cd] Pulumi 인프라 config 외부 주입 및 CD 자동화

### DIFF
--- a/.github/workflows/readygsm-prod-cd.yml
+++ b/.github/workflows/readygsm-prod-cd.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: infra/package-lock.json
 
@@ -85,7 +85,7 @@ jobs:
           echo "image_uri=${IMAGE_URI}" >> $GITHUB_OUTPUT
 
       - name: Copy config files to EC2
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@v1.0.0
         with:
           host: ${{ secrets.PROD_SERVER_HOST }}
           username: ec2-user
@@ -95,7 +95,7 @@ jobs:
           target: "/home/ec2-user/readygsm-files/"
 
       - name: Deploy to EC2
-        uses: appleboy/ssh-action@v1.2.0
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.PROD_SERVER_HOST }}
           username: ec2-user

--- a/.github/workflows/readygsm-prod-cd.yml
+++ b/.github/workflows/readygsm-prod-cd.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           java-version: "21"
           distribution: "temurin"
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: infra/package-lock.json
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
@@ -42,6 +48,26 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Install Pulumi CLI
+        run: |
+          curl -fsSL https://get.pulumi.com | sh
+          echo "$HOME/.pulumi/bin" >> $GITHUB_PATH
+
+      - name: Install infra dependencies
+        working-directory: infra
+        run: npm ci
+
+      - name: Deploy infrastructure
+        working-directory: infra
+        run: |
+          pulumi stack select gsmthemoment-gmail-com/prod
+          pulumi up --yes \
+            --config "readygsm-infra:hostedZoneName=${{ secrets.HOSTED_ZONE_NAME }}" \
+            --config "readygsm-infra:appDomain=${{ secrets.APP_DOMAIN }}"
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
 
       - name: Build and push Docker image to ECR
         id: build-image

--- a/.github/workflows/readygsm-prod-cd.yml
+++ b/.github/workflows/readygsm-prod-cd.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: infra/package-lock.json
 

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -6,5 +6,5 @@ config:
   readygsm-infra:vpcCidr: "10.0.0.0/16"
   readygsm-infra:subnetCidr: "10.0.1.0/24"
   readygsm-infra:availabilityZone: ap-northeast-2a
-  readygsm-infra:dnsTtl: "300"
+  readygsm-infra:dnsTtl: 300
 encryptionsalt: v1:cVFTtUAH9oU=:v1:VZld0iCXc2gkK7iu:qVLSt2ipM9DdK7MVnw0TT7Eex41eVA==

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -3,4 +3,8 @@ config:
   readygsm-infra:environment: prod
   readygsm-infra:ec2InstanceType: t3.small
   readygsm-infra:ec2KeyPairName: readygsm-prod-keypair
+  readygsm-infra:vpcCidr: "10.0.0.0/16"
+  readygsm-infra:subnetCidr: "10.0.1.0/24"
+  readygsm-infra:availabilityZone: ap-northeast-2a
+  readygsm-infra:dnsTtl: "300"
 encryptionsalt: v1:cVFTtUAH9oU=:v1:VZld0iCXc2gkK7iu:qVLSt2ipM9DdK7MVnw0TT7Eex41eVA==

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -3,7 +3,7 @@ import * as aws from "@pulumi/aws";
 
 // ── 설정 ──────────────────────────────────────────────────
 const config = new pulumi.Config();
-const env            = config.get("environment")     ?? "prod";
+const env            = config.require("environment");
 const instanceType   = config.get("ec2InstanceType") ?? "t3.small";
 const keyPairName    = config.require("ec2KeyPairName");
 const vpcCidr        = config.get("vpcCidr")         ?? "10.0.0.0/16";

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -3,16 +3,22 @@ import * as aws from "@pulumi/aws";
 
 // ── 설정 ──────────────────────────────────────────────────
 const config = new pulumi.Config();
-const env = config.get("environment") ?? "prod";
-const instanceType = config.get("ec2InstanceType") ?? "t3.small";
-const keyPairName = config.require("ec2KeyPairName");
+const env            = config.get("environment")     ?? "prod";
+const instanceType   = config.get("ec2InstanceType") ?? "t3.small";
+const keyPairName    = config.require("ec2KeyPairName");
+const vpcCidr        = config.get("vpcCidr")         ?? "10.0.0.0/16";
+const subnetCidr     = config.get("subnetCidr")      ?? "10.0.1.0/24";
+const az             = config.get("availabilityZone") ?? "ap-northeast-2a";
+const hostedZoneName = config.require("hostedZoneName");
+const appDomainName  = config.require("appDomain");
+const dnsTtl         = config.getNumber("dnsTtl")    ?? 300;
 
 const prefix = `readygsm-${env}`;
 const commonTags = { Project: "readygsm", Environment: env };
 
 // ── VPC ───────────────────────────────────────────────────
 const vpc = new aws.ec2.Vpc(`${prefix}-vpc`, {
-    cidrBlock: "10.0.0.0/16",
+    cidrBlock: vpcCidr,
     enableDnsHostnames: true,
     enableDnsSupport: true,
     tags: { ...commonTags, Name: `${prefix}-vpc` },
@@ -27,8 +33,8 @@ const igw = new aws.ec2.InternetGateway(`${prefix}-igw`, {
 // ── Public Subnet ─────────────────────────────────────────
 const publicSubnet = new aws.ec2.Subnet(`${prefix}-subnet-public`, {
     vpcId: vpc.id,
-    cidrBlock: "10.0.1.0/24",
-    availabilityZone: "ap-northeast-2a",
+    cidrBlock: subnetCidr,
+    availabilityZone: az,
     mapPublicIpOnLaunch: true,
     tags: { ...commonTags, Name: `${prefix}-subnet-public` },
 });
@@ -242,15 +248,15 @@ new aws.ecr.LifecyclePolicy(`${prefix}-app-lifecycle`, {
 
 // ── Route 53 A 레코드 (api.ready.hellogsm.kr) ────────────────
 const hostedZone = aws.route53.getZone({
-    name: "hellogsm.kr",
+    name: hostedZoneName,
     privateZone: false,
 });
 
 new aws.route53.Record(`${prefix}-dns`, {
     zoneId: hostedZone.then((hz) => hz.zoneId),
-    name: "api.ready.hellogsm.kr",
+    name: appDomainName,
     type: "A",
-    ttl: 300,
+    ttl: dnsTtl,
     records: [eip.publicIp],
 });
 
@@ -260,4 +266,4 @@ export const ec2InstanceId = ec2.id;
 export const ec2PublicIp = eip.publicIp;
 export const ecrRepositoryUrl = ecrRepo.repositoryUrl;
 export const ecrRepositoryName = ecrRepo.name;
-export const appDomain = "api.ready.hellogsm.kr";
+export const appDomain = appDomainName;


### PR DESCRIPTION
## 개요

IaC 코드(`infra/index.ts`)에 하드코딩된 도메인, CIDR, AZ 등 환경별 가변값을 Pulumi config로 분리하고, 도메인 값은 GitHub Secrets를 통해 CI에서 주입받도록 변경합니다.

## 변경 사항

### `infra/index.ts`

- VPC CIDR, Subnet CIDR, AZ, 도메인, DNS TTL 등 하드코딩 값을 `pulumi.Config`로 읽도록 변경

### `infra/Pulumi.prod.yaml`

- VPC CIDR, Subnet CIDR, AZ, DNS TTL 값을 명시적으로 선언
- `hostedZoneName`, `appDomain`은 GitHub Secrets 주입으로 전환하여 저장소 노출 제거

### `.github/workflows/readygsm-prod-cd.yml`

- Node.js 20 셋업 추가 (Pulumi TypeScript 실행 필요)
- master push 시 `pulumi up` 자동 실행 단계 추가
- 도메인 값을 `HOSTED_ZONE_NAME`, `APP_DOMAIN` GitHub Secrets에서 `--config` 플래그로 주입
- Pulumi state를 Pulumi Cloud로 마이그레이션하여 CI에서 스택 접근 가능하도록 구성