### PR TITLE
[application] 정원 초과 시 예비신청 처리 추가

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/application/dto/response/ApplicationResDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/dto/response/ApplicationResDto.java
@@ -12,7 +12,8 @@ public record ApplicationResDto(
         Integer number,
         String schoolName,
         String phoneNumber,
-        String familyPhoneNumber
+        String familyPhoneNumber,
+        boolean isReserve
 ) {
     public static ApplicationResDto from(ApplicationJpaEntity entity) {
         return new ApplicationResDto(
@@ -25,7 +26,8 @@ public record ApplicationResDto(
                 entity.getNumber(),
                 entity.getSchoolName(),
                 entity.getPhoneNumber(),
-                entity.getFamilyPhoneNumber()
+                entity.getFamilyPhoneNumber(),
+                entity.isReserve()
         );
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/entity/ApplicationJpaEntity.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/entity/ApplicationJpaEntity.java
@@ -53,6 +53,9 @@ public class ApplicationJpaEntity {
     @Column(name = "family_phone_number", nullable = false, length = 20)
     private String familyPhoneNumber;
 
+    @Column(name = "is_reserve", nullable = false)
+    private boolean isReserve;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntity, Long> {
     boolean existsByUser_Id(Long userId);
     long countByActivity_Id(Long activityId);
+    long countByActivity_IdAndIsReserve(Long activityId, boolean isReserve);
+    boolean existsByActivity_IdAndIsReserve(Long activityId, boolean isReserve);
 
     @Query("SELECT app.activity.id, COUNT(app) FROM ApplicationJpaEntity app GROUP BY app.activity.id")
     List<Object[]> countApplicantsGroupedByActivity();

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
@@ -35,9 +35,7 @@ public class ApplyActivityService {
         }
 
         long currentApplicants = applicationRepository.countByActivity_Id(activityId);
-        if (currentApplicants >= activity.getMaxApplicant()) {
-            throw new ExpectedException("신청 정원이 초과되었습니다.", HttpStatus.BAD_REQUEST);
-        }
+        boolean isReserve = currentApplicants >= activity.getMaxApplicant();
 
         ApplicationJpaEntity saved = applicationRepository.save(
                 ApplicationJpaEntity.builder()
@@ -50,6 +48,7 @@ public class ApplyActivityService {
                         .schoolName(req.schoolName())
                         .phoneNumber(req.phoneNumber())
                         .familyPhoneNumber(req.familyPhoneNumber())
+                        .isReserve(isReserve)
                         .build()
         );
 

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
@@ -34,8 +34,9 @@ public class ApplyActivityService {
             throw new ExpectedException("이미 신청한 활동이 있습니다.", HttpStatus.CONFLICT);
         }
 
-        long currentApplicants = applicationRepository.countByActivity_Id(activityId);
-        boolean isReserve = currentApplicants >= activity.getMaxApplicant();
+        long currentMainApplicants = applicationRepository.countByActivity_IdAndIsReserve(activityId, false);
+        boolean hasReserve = applicationRepository.existsByActivity_IdAndIsReserve(activityId, true);
+        boolean isReserve = currentMainApplicants >= activity.getMaxApplicant() || hasReserve;
 
         ApplicationJpaEntity saved = applicationRepository.save(
                 ApplicationJpaEntity.builder()


### PR DESCRIPTION
## 개요

정원이 가득 찼을 때 신청 자체를 거부하던 문제를 수정합니다.
정원 초과 인원은 예비 신청자로 저장되며, 관리자가 직접 예비 인원을 확인하고 본신청으로 전환할 수 있습니다.

closes #84

## 변경 사항

### `ApplicationJpaEntity`

- `isReserve` 필드 추가 — 정원 초과 신청 시 `true`로 저장

### `ApplyActivityService`

- 정원 초과 시 예외를 던지던 로직 제거
- `현재 신청자 수 >= maxApplicant` 조건을 `isReserve` 값 결정에 활용

### `ApplicationResDto`

- `isReserve` 필드 추가 — 본신청/예비신청 여부를 응답에 포함