### PR TITLE
[ci/cd] 스테이징 배포 시 git pull 충돌로 인한 배포 누락 수정

### DIFF
--- a/.github/workflows/readygsm-stage-cd.yml
+++ b/.github/workflows/readygsm-stage-cd.yml
@@ -20,13 +20,16 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           envs: GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,MYSQL_USERNAME,MYSQL_PASSWORD,REDIS_PASSWORD
           script: |
+            set -e
             export GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID
             export GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
             export GOOGLE_REDIRECT_URI=$GOOGLE_REDIRECT_URI
             export MYSQL_USERNAME=$MYSQL_USERNAME
             export MYSQL_PASSWORD=$MYSQL_PASSWORD
             export REDIS_PASSWORD=$REDIS_PASSWORD
-            cd $HOME/Downloads/readygsm-server && git pull origin develop
+            cd $HOME/Downloads/readygsm-server
+            git fetch origin develop
+            git reset --hard origin/develop
             bash $HOME/Downloads/readygsm-server/scripts/stage/deploy.sh
         env:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}


### PR DESCRIPTION
## 개요

스테이징 서버에서 `git pull origin develop`이 `gradlew` 로컬 변경 충돌로 매번 Aborting 되고 있었습니다. 그런데 이후 단계(`gradlew bootJar`, `docker compose build`)가 실패한 pull과 무관하게 계속 실행되어, 기존 stale 코드로 빌드 및 재배포가 이뤄지고 CI는 "성공"으로 표시되는 문제가 있었습니다.

실제로 2026-06-15 배포부터 git pull이 계속 실패하고 있었고, PR #85(`isReserve` 필드 추가)도 스테이징에 반영되지 않은 상태였습니다.

## 변경 사항

### `.github/workflows/readygsm-stage-cd.yml`

- `git pull origin develop` → `git fetch origin develop && git reset --hard origin/develop`로 변경하여 서버의 로컬 변경 사항과 무관하게 항상 origin/develop과 동일한 상태로 강제 동기화
- 스크립트 상단에 `set -e` 추가 — 이후 단계 중 하나라도 실패하면 워크플로우가 실패로 표시되어 더 이상 배포 실패가 "성공"으로 위장되지 않음