### PR TITLE
[global] 제약 조건 예외 메시지 세부화

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/global/config/ValidationExceptionHandler.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/ValidationExceptionHandler.java
@@ -25,6 +25,8 @@ import java.util.stream.Collectors;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class ValidationExceptionHandler {
 
+    private static final String DEFAULT_MESSAGE = "올바르지 않은 입력값입니다.";
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public CommonApiResponse<?> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
         String message = ex.getBindingResult().getAllErrors().stream()
@@ -42,13 +44,19 @@ public class ValidationExceptionHandler {
     }
 
     private String formatError(ObjectError error) {
+        // 메시지가 null이면 Collectors.joining의 StringJoiner가 NPE를 던져 500이 나므로 기본값으로 대체
+        String message = error.getDefaultMessage() != null ? error.getDefaultMessage() : DEFAULT_MESSAGE;
         if (error instanceof FieldError fieldError) {
-            return fieldError.getField() + ": " + fieldError.getDefaultMessage();
+            return fieldError.getField() + ": " + message;
         }
-        return error.getDefaultMessage();
+        return message;
     }
 
     private String formatViolation(ConstraintViolation<?> violation) {
-        return violation.getPropertyPath() + ": " + violation.getMessage();
+        // getPropertyPath()는 "메서드명.객체명.필드명" 형태이므로 마지막 필드명만 추출
+        String propertyPath = violation.getPropertyPath().toString();
+        String fieldName = propertyPath.substring(propertyPath.lastIndexOf('.') + 1);
+        String message = violation.getMessage() != null ? violation.getMessage() : DEFAULT_MESSAGE;
+        return fieldName + ": " + message;
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/global/config/ValidationExceptionHandler.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/ValidationExceptionHandler.java
@@ -14,13 +14,6 @@ import team.themoment.sdk.response.CommonApiResponse;
 
 import java.util.stream.Collectors;
 
-/**
- * Bean Validation(@Valid / @Validated) 실패 시 발생하는 예외를 처리한다.
- *
- * <p>the-sdk의 GlobalExceptionHandler는 ExpectedException만 처리하므로,
- * 검증 실패 예외는 잡히지 않아 본문 없는 400만 응답된다. 이 핸들러가 실패한 필드별
- * 메시지를 모아 SDK 표준 포맷({@link CommonApiResponse#error})으로 응답한다.
- */
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class ValidationExceptionHandler {
@@ -44,7 +37,6 @@ public class ValidationExceptionHandler {
     }
 
     private String formatError(ObjectError error) {
-        // 메시지가 null이면 Collectors.joining의 StringJoiner가 NPE를 던져 500이 나므로 기본값으로 대체
         String message = error.getDefaultMessage() != null ? error.getDefaultMessage() : DEFAULT_MESSAGE;
         if (error instanceof FieldError fieldError) {
             return fieldError.getField() + ": " + message;
@@ -53,7 +45,6 @@ public class ValidationExceptionHandler {
     }
 
     private String formatViolation(ConstraintViolation<?> violation) {
-        // getPropertyPath()는 "메서드명.객체명.필드명" 형태이므로 마지막 필드명만 추출
         String propertyPath = violation.getPropertyPath().toString();
         String fieldName = propertyPath.substring(propertyPath.lastIndexOf('.') + 1);
         String message = violation.getMessage() != null ? violation.getMessage() : DEFAULT_MESSAGE;

--- a/src/main/java/team/themoment/readygsmserver/global/config/ValidationExceptionHandler.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/ValidationExceptionHandler.java
@@ -1,0 +1,54 @@
+package team.themoment.readygsmserver.global.config;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import team.themoment.sdk.response.CommonApiResponse;
+
+import java.util.stream.Collectors;
+
+/**
+ * Bean Validation(@Valid / @Validated) 실패 시 발생하는 예외를 처리한다.
+ *
+ * <p>the-sdk의 GlobalExceptionHandler는 ExpectedException만 처리하므로,
+ * 검증 실패 예외는 잡히지 않아 본문 없는 400만 응답된다. 이 핸들러가 실패한 필드별
+ * 메시지를 모아 SDK 표준 포맷({@link CommonApiResponse#error})으로 응답한다.
+ */
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class ValidationExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public CommonApiResponse<?> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getAllErrors().stream()
+                .map(this::formatError)
+                .collect(Collectors.joining(", "));
+        return CommonApiResponse.error(message, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public CommonApiResponse<?> handleConstraintViolation(ConstraintViolationException ex) {
+        String message = ex.getConstraintViolations().stream()
+                .map(this::formatViolation)
+                .collect(Collectors.joining(", "));
+        return CommonApiResponse.error(message, HttpStatus.BAD_REQUEST);
+    }
+
+    private String formatError(ObjectError error) {
+        if (error instanceof FieldError fieldError) {
+            return fieldError.getField() + ": " + fieldError.getDefaultMessage();
+        }
+        return error.getDefaultMessage();
+    }
+
+    private String formatViolation(ConstraintViolation<?> violation) {
+        return violation.getPropertyPath() + ": " + violation.getMessage();
+    }
+}


### PR DESCRIPTION
## 개요

DTO 제약 조건에 맞지 않는 요청이 와도 본문 없는 **400 Bad Request**만 응답되어, 클라이언트가 어떤 검증이 실패했는지 알 수 없던 문제를 수정합니다.

원인은 검증 실패 예외를 처리하는 핸들러가 없었기 때문입니다. 검증 자체(`@NotBlank`, `@Size`, `@Min`, `@AssertTrue` 등)와 메시지는 이미 DTO에 작성돼 있었으나, `@Valid` 실패 시 발생하는 `MethodArgumentNotValidException`을 잡는 곳이 없었습니다. 공통 라이브러리 `the-sdk`의 `GlobalExceptionHandler`는 `ExpectedException`만 처리합니다.

이제 검증 실패 시 DTO에 정의된 메시지가 SDK 표준 응답 포맷에 담겨 전달됩니다.

## 변경 사항

### `ValidationExceptionHandler` (신규)

프로젝트 전역 `@RestControllerAdvice`를 추가했습니다. `@Valid`를 사용하는 모든 엔드포인트에 일괄 적용됩니다.

- **`MethodArgumentNotValidException`** (`@Valid @RequestBody` 실패) 처리
  - 필드 검증(`FieldError`)은 `field: 메시지` 형태로, `@AssertTrue` 같은 교차 필드(클래스 레벨) 검증은 메시지만 사용
  - 실패한 모든 항목을 `", "`로 join하여 어떤 제약이 깨졌는지 한 번에 파악 가능
- **`ConstraintViolationException`** (`@Validated` 경로/쿼리 파라미터 검증) 방어적 추가
- 응답은 SDK 표준 포맷 `CommonApiResponse.error(message, HttpStatus.BAD_REQUEST)`로 반환
  - SDK의 `GlobalExceptionHandler`는 `ExpectedException`만 처리하므로 예외 타입이 겹치지 않아 충돌 없음

## 응답 예시

```json
{
  "status": "BAD_REQUEST",
  "code": 400,
  "message": "name: 공백일 수 없습니다, maxApplicant: 1 이상이어야 합니다, 신청 시작 시각은 종료 시각보다 이전이어야 합니다."
}
```