### PR TITLE
[application] USER 역할에 대한 신청기간 검증 로직 추가

### DIFF
--- a/infra/index.ts
+++ b/infra/index.ts
@@ -204,7 +204,7 @@ const ec2 = new aws.ec2.Instance(`${prefix}-ec2`, {
         httpTokens: "required", // IMDSv2 강제
     },
     tags: { ...commonTags, Name: `${prefix}-ec2` },
-});
+}, { ignoreChanges: ["ami", "rootBlockDevice"] });
 
 // ── Elastic IP ────────────────────────────────────────────
 const eip = new aws.ec2.Eip(`${prefix}-eip`, {

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
@@ -34,7 +34,7 @@ public class ApplyActivityService {
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         if (user.getRole() == Role.USER) {
-            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime now = LocalDateTime.now(java.time.ZoneId.of("Asia/Seoul"));
             if (now.isBefore(activity.getRegistrationStartAt()) || now.isAfter(activity.getRegistrationEndAt())) {
                 throw new ExpectedException("신청 기간이 아닙니다.", HttpStatus.BAD_REQUEST);
             }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
@@ -11,8 +11,11 @@ import team.themoment.readygsmserver.domain.application.dto.response.Application
 import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
 import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
 import team.themoment.readygsmserver.domain.user.entity.UserJpaEntity;
+import team.themoment.readygsmserver.domain.user.entity.constant.Role;
 import team.themoment.readygsmserver.domain.user.repository.UserRepository;
 import team.themoment.sdk.exception.ExpectedException;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +32,13 @@ public class ApplyActivityService {
 
         UserJpaEntity user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        if (user.getRole() == Role.USER) {
+            LocalDateTime now = LocalDateTime.now();
+            if (now.isBefore(activity.getRegistrationStartAt()) || now.isAfter(activity.getRegistrationEndAt())) {
+                throw new ExpectedException("신청 기간이 아닙니다.", HttpStatus.BAD_REQUEST);
+            }
+        }
 
         if (applicationRepository.existsByUser_Id(userId)) {
             throw new ExpectedException("이미 신청한 활동이 있습니다.", HttpStatus.CONFLICT);


### PR DESCRIPTION
## 개요

`ApplyActivityService`에 신청기간 검증 로직이 없어, 등록 기간 외에도 신청이 가능한 문제를 수정합니다.

단, 관리자 등 운영 목적의 신청은 기간 제한 없이 허용해야 하므로, `USER` 역할에 한해서만 검증이 동작하도록 구현했습니다.

## 변경 사항

### `ApplyActivityService`

- `USER` 역할일 때만 현재 시각을 `registrationStartAt` ~ `registrationEndAt` 범위와 비교
- 기간 외 신청 시 `400 Bad Request` 응답
- `ADMIN`, `ROOT` 역할은 기간 제한 없이 신청 가능
