### PR TITLE
[application] 정식 신청 취소/삭제 시 예비 신청자 승격 로직 추가

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/application/entity/ApplicationJpaEntity.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/entity/ApplicationJpaEntity.java
@@ -56,6 +56,10 @@ public class ApplicationJpaEntity {
     @Column(name = "is_reserve", nullable = false)
     private boolean isReserve;
 
+    public void promote() {
+        this.isReserve = false;
+    }
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
@@ -15,7 +15,7 @@ public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntit
     long countByActivity_IdAndIsReserve(Long activityId, boolean isReserve);
     boolean existsByActivity_IdAndIsReserve(Long activityId, boolean isReserve);
     Optional<ApplicationJpaEntity> findByActivity_IdAndUser_Id(Long activityId, Long userId);
-    Optional<ApplicationJpaEntity> findFirstByActivity_IdAndIsReserveTrueOrderByCreatedAtAsc(Long activityId);
+    Optional<ApplicationJpaEntity> findFirstByActivity_IdAndIsReserveTrueOrderByCreatedAtAscIdAsc(Long activityId);
 
     @Query("SELECT app.activity.id, COUNT(app) FROM ApplicationJpaEntity app GROUP BY app.activity.id")
     List<Object[]> countApplicantsGroupedByActivity();

--- a/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
@@ -14,6 +14,8 @@ public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntit
     long countByActivity_Id(Long activityId);
     long countByActivity_IdAndIsReserve(Long activityId, boolean isReserve);
     boolean existsByActivity_IdAndIsReserve(Long activityId, boolean isReserve);
+    Optional<ApplicationJpaEntity> findByActivity_IdAndUser_Id(Long activityId, Long userId);
+    Optional<ApplicationJpaEntity> findFirstByActivity_IdAndIsReserveTrueOrderByCreatedAtAsc(Long activityId);
 
     @Query("SELECT app.activity.id, COUNT(app) FROM ApplicationJpaEntity app GROUP BY app.activity.id")
     List<Object[]> countApplicantsGroupedByActivity();

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/CancelApplicationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/CancelApplicationService.java
@@ -23,7 +23,7 @@ public class CancelApplicationService {
         applicationRepository.delete(application);
 
         if (wasConfirmed) {
-            applicationRepository.findFirstByActivity_IdAndIsReserveTrueOrderByCreatedAtAsc(activityId)
+            applicationRepository.findFirstByActivity_IdAndIsReserveTrueOrderByCreatedAtAscIdAsc(activityId)
                     .ifPresent(ApplicationJpaEntity::promote);
         }
     }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/CancelApplicationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/CancelApplicationService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
 import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
@@ -15,9 +16,15 @@ public class CancelApplicationService {
     private final ApplicationRepository applicationRepository;
 
     public void execute(Long userId, Long activityId) {
-        int deleted = applicationRepository.deleteByActivity_IdAndUser_Id(activityId, userId);
-        if (deleted == 0) {
-            throw new ExpectedException("신청 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        ApplicationJpaEntity application = applicationRepository.findByActivity_IdAndUser_Id(activityId, userId)
+                .orElseThrow(() -> new ExpectedException("신청 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        boolean wasConfirmed = !application.isReserve();
+        applicationRepository.delete(application);
+
+        if (wasConfirmed) {
+            applicationRepository.findFirstByActivity_IdAndIsReserveTrueOrderByCreatedAtAsc(activityId)
+                    .ifPresent(ApplicationJpaEntity::promote);
         }
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/DeleteApplicationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/DeleteApplicationService.java
@@ -24,7 +24,7 @@ public class DeleteApplicationService {
         applicationRepository.delete(application);
 
         if (wasConfirmed) {
-            applicationRepository.findFirstByActivity_IdAndIsReserveTrueOrderByCreatedAtAsc(activityId)
+            applicationRepository.findFirstByActivity_IdAndIsReserveTrueOrderByCreatedAtAscIdAsc(activityId)
                     .ifPresent(ApplicationJpaEntity::promote);
         }
     }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/DeleteApplicationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/DeleteApplicationService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
 import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
@@ -15,9 +16,16 @@ public class DeleteApplicationService {
     private final ApplicationRepository applicationRepository;
 
     public void execute(Long applicationId) {
-        int deleted = applicationRepository.deleteByApplicationId(applicationId);
-        if (deleted == 0) {
-            throw new ExpectedException("신청 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        ApplicationJpaEntity application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new ExpectedException("신청 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        boolean wasConfirmed = !application.isReserve();
+        Long activityId = application.getActivity().getId();
+        applicationRepository.delete(application);
+
+        if (wasConfirmed) {
+            applicationRepository.findFirstByActivity_IdAndIsReserveTrueOrderByCreatedAtAsc(activityId)
+                    .ifPresent(ApplicationJpaEntity::promote);
         }
     }
 }


### PR DESCRIPTION
## 개요

정식 신청자(`isReserve: false`)가 취소 또는 삭제될 때 예비 신청자를 승격하는 로직이 없어, 빈 정원이 생겨도 기존 예비 신청자들이 계속 `isReserve: true` 상태로 남는 문제를 수정합니다.

`ApplyActivityService`의 `hasReserve` 조건(`existsByActivity_IdAndIsReserve(activityId, true)`)으로 인해, 예비 신청자가 한 명이라도 존재하면 이후 모든 신청자가 빈 정원과 무관하게 예비로 처리되는 연쇄 버그가 발생했습니다.

## 변경 사항

### `ApplicationJpaEntity`

- `promote()` 메서드 추가 — `isReserve`를 `false`로 변경하여 정식 신청자로 승격

### `ApplicationRepository`

- `findByActivity_IdAndUser_Id` 추가 — 취소 시 신청 엔티티 조회에 사용
- `findFirstByActivity_IdAndIsReserveTrueOrderByCreatedAtAsc` 추가 — 가장 먼저 신청한 예비자를 조회하여 승격 대상 결정

### `CancelApplicationService`

- 취소 대상이 정식 신청자(`isReserve: false`)인 경우 가장 오래된 예비 신청자를 승격

### `DeleteApplicationService`

- 삭제 대상이 정식 신청자인 경우 동일하게 예비 신청자를 승격

https://claude.ai/code/session_01HaVxhfKRpFFexo9Q3Rm24g