### PR TITLE
[application] 신청 기간 종료 후 취소 차단 검증 추가

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
@@ -1,5 +1,6 @@
 package team.themoment.readygsmserver.domain.application.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -14,6 +15,7 @@ public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntit
     long countByActivity_Id(Long activityId);
     long countByActivity_IdAndIsReserve(Long activityId, boolean isReserve);
     boolean existsByActivity_IdAndIsReserve(Long activityId, boolean isReserve);
+    @EntityGraph(attributePaths = {"activity"})
     Optional<ApplicationJpaEntity> findByActivity_IdAndUser_Id(Long activityId, Long userId);
     Optional<ApplicationJpaEntity> findFirstByActivity_IdAndIsReserveTrueOrderByCreatedAtAscIdAsc(Long activityId);
 

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/CancelApplicationService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/CancelApplicationService.java
@@ -8,6 +8,9 @@ import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEnt
 import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -18,6 +21,11 @@ public class CancelApplicationService {
     public void execute(Long userId, Long activityId) {
         ApplicationJpaEntity application = applicationRepository.findByActivity_IdAndUser_Id(activityId, userId)
                 .orElseThrow(() -> new ExpectedException("신청 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        if (now.isAfter(application.getActivity().getRegistrationEndAt())) {
+            throw new ExpectedException("신청 기간이 지나 취소할 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
 
         boolean wasConfirmed = !application.isReserve();
         applicationRepository.delete(application);


### PR DESCRIPTION
## 개요

`CancelApplicationService`에 신청 기간 검증 로직이 없어, `registrationEndAt` 이후에도 신청 취소가 가능한 문제를 수정합니다.

신청 기간이 종료된 이후에는 예비 신청자가 이미 정원으로 승격되었을 수 있습니다. 이 시점 이후 취소가 발생하면 승격된 예비 신청자에게 정원 편입 사실을 전달하는 데 혼란이 생깁니다.

## 변경 사항

### `CancelApplicationService`

- 취소 요청 시 KST 기준 현재 시각이 `registrationEndAt`을 초과한 경우 `400 Bad Request` 응답
- `ApplyActivityService`의 신청 기간 검증과 동일한 `ZoneId.of("Asia/Seoul")` 타임존 사용

closes #92