### PR TITLE
[application] isReserve 여부에 따른 엑셀 시트 분리 출력

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
@@ -46,26 +46,27 @@ public class ExportApplicationExcelService {
 
         try (XSSFWorkbook workbook = new XSSFWorkbook()) {
             Sheet sheet = workbook.createSheet("신청자 목록");
+            Sheet reserveSheet = workbook.createSheet("신청 대기자 목록");
 
             Row headerRow = sheet.createRow(0);
+            Row reservedHeaderRow = reserveSheet.createRow(0);
             for (int i = 0; i < HEADERS.length; i++) {
                 headerRow.createCell(i).setCellValue(HEADERS[i]);
+                reservedHeaderRow.createCell(i).setCellValue(HEADERS[i]);
             }
 
-            for (int i = 0; i < applications.size(); i++) {
-                ApplicationJpaEntity app = applications.get(i);
-                Row row = sheet.createRow(i + 1);
-                row.createCell(COL_NAME).setCellValue(app.getName());
-                row.createCell(COL_GRADE).setCellValue(app.getGrade());
-                row.createCell(COL_CLASS_NUMBER).setCellValue(app.getClassNumber());
-                row.createCell(COL_NUMBER).setCellValue(app.getNumber());
-                row.createCell(COL_SCHOOL_NAME).setCellValue(app.getSchoolName());
-                row.createCell(COL_PHONE_NUMBER).setCellValue(app.getPhoneNumber());
-                row.createCell(COL_FAMILY_PHONE_NUMBER).setCellValue(app.getFamilyPhoneNumber());
+            int sheetRow = 1, reserveSheetRow = 1;
+            for (ApplicationJpaEntity app : applications) {
+                if (app.isReserve()) {
+                    createApplicationRow(reserveSheet, app, reserveSheetRow++);
+                } else {
+                    createApplicationRow(sheet, app, sheetRow++);
+                }
             }
 
             for (int i = 0; i < COL_WIDTHS.length; i++) {
                 sheet.setColumnWidth(i, COL_WIDTHS[i]);
+                reserveSheet.setColumnWidth(i, COL_WIDTHS[i]);
             }
 
             ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -74,5 +75,16 @@ public class ExportApplicationExcelService {
         } catch (IOException e) {
             throw new RuntimeException("엑셀 파일 생성에 실패했습니다.", e);
         }
+    }
+
+    private void createApplicationRow(Sheet sheet, ApplicationJpaEntity app, int rowIndex) {
+        Row row = sheet.createRow(rowIndex);
+        row.createCell(COL_NAME).setCellValue(app.getName());
+        row.createCell(COL_GRADE).setCellValue(app.getGrade());
+        row.createCell(COL_CLASS_NUMBER).setCellValue(app.getClassNumber());
+        row.createCell(COL_NUMBER).setCellValue(app.getNumber());
+        row.createCell(COL_SCHOOL_NAME).setCellValue(app.getSchoolName());
+        row.createCell(COL_PHONE_NUMBER).setCellValue(app.getPhoneNumber());
+        row.createCell(COL_FAMILY_PHONE_NUMBER).setCellValue(app.getFamilyPhoneNumber());
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
@@ -55,7 +55,8 @@ public class ExportApplicationExcelService {
                 reservedHeaderRow.createCell(i).setCellValue(HEADERS[i]);
             }
 
-            int sheetRow = 1, reserveSheetRow = 1;
+            int sheetRow = 1;
+            int reserveSheetRow = 1;
             for (ApplicationJpaEntity app : applications) {
                 if (app.isReserve()) {
                     createApplicationRow(reserveSheet, app, reserveSheetRow++);


### PR DESCRIPTION
## 변경 사항

`ExportApplicationExcelService`에서 엑셀 출력 시 `isReserve` 여부에 따라 신청자와 대기자를 별도 시트에 분리하여 출력하도록 수정하였습니다.

## 수정 내용

- `신청 대기자 목록` 시트를 추가하였습니다.
- 신청 목록 조회 시 `isReserve` 값에 따라 일반 신청자는 `신청자 목록` 시트에, 대기자는 `신청 대기자 목록` 시트에 각각 기록되도록 분기 처리하였습니다.
- 두 시트 모두 동일한 헤더 및 컬럼 너비가 적용되도록 수정하였습니다.
- 행 생성 로직을 `createApplicationRow` 메서드로 추출하여 중복을 제거하였습니다.

## 테스트 방법

- 대기자(`isReserve = true`)와 일반 신청자(`isReserve = false`)가 혼재한 상태에서 엑셀 내보내기 API 호출
- 생성된 엑셀 파일의 `신청자 목록` 시트에 일반 신청자만 포함되는지 확인
- 생성된 엑셀 파일의 `신청 대기자 목록` 시트에 대기자만 포함되는지 확인