### PR TITLE
[application] 엑셀 파일명을 활동명_타임스탬프 형식으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'team.themoment'
-version = '20260625.2'
+version = 'v20260625.2'
 description = 'readygsm-server'
 
 java {

--- a/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 import team.themoment.readygsmserver.domain.application.dto.request.ApplicationReqDto;
 import team.themoment.readygsmserver.domain.application.dto.response.ApplicationResDto;
+import team.themoment.readygsmserver.domain.application.dto.response.ExcelExportResult;
 import team.themoment.readygsmserver.domain.application.service.ApplyActivityService;
 import team.themoment.readygsmserver.domain.application.service.CancelApplicationService;
 import team.themoment.readygsmserver.domain.application.service.DeleteApplicationService;
@@ -103,14 +104,14 @@ public class ApplicationController {
     })
     @GetMapping("/admin/excel")
     public ResponseEntity<byte[]> exportExcel(@RequestParam Long activityId) {
-        byte[] excelBytes = exportApplicationExcelService.execute(activityId);
+        ExcelExportResult result = exportApplicationExcelService.execute(activityId);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
         headers.setContentDisposition(
-                ContentDisposition.attachment().filename("applications.xlsx", StandardCharsets.UTF_8).build()
+                ContentDisposition.attachment().filename(result.fileName(), StandardCharsets.UTF_8).build()
         );
 
-        return ResponseEntity.ok().headers(headers).body(excelBytes);
+        return ResponseEntity.ok().headers(headers).body(result.content());
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/dto/response/ExcelExportResult.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/dto/response/ExcelExportResult.java
@@ -1,0 +1,7 @@
+package team.themoment.readygsmserver.domain.application.dto.response;
+
+public record ExcelExportResult(
+        String fileName,
+        byte[] content
+) {
+}

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
@@ -36,7 +36,6 @@ public class ExportApplicationExcelService {
     private static final int COL_PHONE_NUMBER = 5;
     private static final int COL_FAMILY_PHONE_NUMBER = 6;
 
-    // POI 컬럼 너비 단위: 1/256 문자 폭
     private static final int[] COL_WIDTHS = {
             10 * 256,  // 이름
             6 * 256,   // 학년
@@ -52,7 +51,6 @@ public class ExportApplicationExcelService {
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
-    // 파일 시스템에서 금지하는 문자(\ / : * ? " < > |)와 제어 문자
     private static final String ILLEGAL_FILE_NAME_CHARS = "[\\\\/:*?\"<>|\\x00-\\x1F]";
 
     private final ApplicationRepository applicationRepository;
@@ -74,7 +72,6 @@ public class ExportApplicationExcelService {
         return sanitizeFileName(activityName) + "_" + timestamp + ".xlsx";
     }
 
-    // 금지 문자를 공백으로 치환한 뒤 연속 공백과 양끝 공백을 정리한다
     private String sanitizeFileName(String activityName) {
         return activityName
                 .replaceAll(ILLEGAL_FILE_NAME_CHARS, " ")

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
@@ -52,6 +52,9 @@ public class ExportApplicationExcelService {
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
+    // 파일 시스템에서 금지하는 문자(\ / : * ? " < > |)와 제어 문자
+    private static final String ILLEGAL_FILE_NAME_CHARS = "[\\\\/:*?\"<>|\\x00-\\x1F]";
+
     private final ApplicationRepository applicationRepository;
     private final ActivityRepository activityRepository;
 
@@ -68,7 +71,15 @@ public class ExportApplicationExcelService {
 
     private String buildFileName(String activityName) {
         String timestamp = LocalDateTime.now(KST).format(FILE_NAME_TIMESTAMP_FORMATTER);
-        return activityName + "_" + timestamp + ".xlsx";
+        return sanitizeFileName(activityName) + "_" + timestamp + ".xlsx";
+    }
+
+    // 금지 문자를 공백으로 치환한 뒤 연속 공백과 양끝 공백을 정리한다
+    private String sanitizeFileName(String activityName) {
+        return activityName
+                .replaceAll(ILLEGAL_FILE_NAME_CHARS, " ")
+                .replaceAll("\\s+", " ")
+                .trim();
     }
 
     private byte[] createExcel(List<ApplicationJpaEntity> applications) {

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ExportApplicationExcelService.java
@@ -4,13 +4,21 @@ import lombok.RequiredArgsConstructor;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import team.themoment.sdk.exception.ExpectedException;
 import org.springframework.transaction.annotation.Transactional;
+import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
+import team.themoment.readygsmserver.domain.activity.repository.ActivityRepository;
+import team.themoment.readygsmserver.domain.application.dto.response.ExcelExportResult;
 import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
 import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Service
@@ -39,11 +47,31 @@ public class ExportApplicationExcelService {
             16 * 256   // 보호자 연락처
     };
 
-    private final ApplicationRepository applicationRepository;
+    private static final DateTimeFormatter FILE_NAME_TIMESTAMP_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
 
-    public byte[] execute(Long activityId) {
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final ApplicationRepository applicationRepository;
+    private final ActivityRepository activityRepository;
+
+    public ExcelExportResult execute(Long activityId) {
+        ActivityJpaEntity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new ExpectedException("활동을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
         List<ApplicationJpaEntity> applications = applicationRepository.findAllByActivity_Id(activityId);
 
+        byte[] content = createExcel(applications);
+        String fileName = buildFileName(activity.getName());
+        return new ExcelExportResult(fileName, content);
+    }
+
+    private String buildFileName(String activityName) {
+        String timestamp = LocalDateTime.now(KST).format(FILE_NAME_TIMESTAMP_FORMATTER);
+        return activityName + "_" + timestamp + ".xlsx";
+    }
+
+    private byte[] createExcel(List<ApplicationJpaEntity> applications) {
         try (XSSFWorkbook workbook = new XSSFWorkbook()) {
             Sheet sheet = workbook.createSheet("신청자 목록");
             Sheet reserveSheet = workbook.createSheet("신청 대기자 목록");


### PR DESCRIPTION
## 개요

활동 신청자 엑셀 출력 시 파일명을 고정값(`applications.xlsx`)에서 `활동명_yyyyMMdd_HHmmss.xlsx` 형식으로 변경했습니다.

예시: `소프트웨어개발과 체험_20260626_095801.xlsx`

## 변경 사항

- `ExcelExportResult` record 추가 — 파일명과 엑셀 바이트를 함께 반환
- `ExportApplicationExcelService`
  - `ActivityRepository`로 활동을 조회해 활동명을 파일명에 사용 (없으면 404 `ExpectedException`)
  - 타임스탬프는 `Asia/Seoul`(KST) 기준으로 고정해 서버 타임존과 무관하게 동작
  - 엑셀 생성 로직을 `createExcel`로 분리
- `ApplicationController` — 서비스가 반환한 파일명을 `Content-Disposition`에 사용 (한글/공백 대응 위해 UTF-8 인코딩 유지)

## 참고

- 파일명에 한글·공백이 포함될 수 있어 `filename(..., StandardCharsets.UTF_8)`로 인코딩합니다.
