### PR TITLE
[ci/cd] MySQL S3 백업 자동화 추가

### DIFF
--- a/.github/workflows/readygsm-prod-cd.yml
+++ b/.github/workflows/readygsm-prod-cd.yml
@@ -93,7 +93,7 @@ jobs:
           username: ec2-user
           key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
           port: 22
-          source: "deploy/compose.prod.yml,docker/nginx.conf"
+          source: "deploy/compose.prod.yml,deploy/backup-mysql.sh,docker/nginx.conf"
           target: "/home/ec2-user/readygsm-files/"
 
       - name: Deploy to EC2
@@ -111,6 +111,11 @@ jobs:
             cp /home/ec2-user/readygsm-files/deploy/compose.prod.yml /home/ec2-user/readygsm/compose.prod.yml
             mkdir -p /home/ec2-user/readygsm/nginx
             cp /home/ec2-user/readygsm-files/docker/nginx.conf /home/ec2-user/readygsm/nginx/nginx.conf
+            cp /home/ec2-user/readygsm-files/deploy/backup-mysql.sh /home/ec2-user/readygsm/backup-mysql.sh
+            chmod +x /home/ec2-user/readygsm/backup-mysql.sh
+
+            # cron job 등록 (중복 방지)
+            (crontab -l 2>/dev/null | grep -v "backup-mysql"; echo "0 3 * * * /home/ec2-user/readygsm/backup-mysql.sh >> /var/log/mysql-backup.log 2>&1") | crontab -
 
             cd /home/ec2-user/readygsm
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'team.themoment'
-version = 'v20260626.0'
+version = 'v20260626.1'
 description = 'readygsm-server'
 
 java {

--- a/deploy/backup-mysql.sh
+++ b/deploy/backup-mysql.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 source /home/ec2-user/readygsm/.env
 

--- a/deploy/backup-mysql.sh
+++ b/deploy/backup-mysql.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+source /home/ec2-user/readygsm/.env
+
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+S3_BUCKET="readygsm-prod-backup"
+
+docker exec readygsm-mysql mysqldump \
+  -u root -p"${PROD_MYSQL_ROOT_PASSWORD}" readygsm \
+  | gzip | aws s3 cp - "s3://${S3_BUCKET}/mysql/backup_${TIMESTAMP}.sql.gz"

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -145,6 +145,14 @@ const backupBucket = new aws.s3.BucketV2(`${prefix}-backup`, {
     tags: { ...commonTags, Name: `${prefix}-backup` },
 });
 
+new aws.s3.BucketPublicAccessBlock(`${prefix}-backup-public-access-block`, {
+    bucket: backupBucket.id,
+    blockPublicAcls: true,
+    blockPublicPolicy: true,
+    ignorePublicAcls: true,
+    restrictPublicBuckets: true,
+});
+
 new aws.s3.BucketLifecycleConfigurationV2(`${prefix}-backup-lifecycle`, {
     bucket: backupBucket.id,
     rules: [{

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -139,6 +139,34 @@ new aws.iam.RolePolicy(`${prefix}-ec2-ecr-policy`, {
     }),
 });
 
+// ── S3 백업 버킷 ──────────────────────────────────────────
+const backupBucket = new aws.s3.BucketV2(`${prefix}-backup`, {
+    bucket: `${prefix}-backup`,
+    tags: { ...commonTags, Name: `${prefix}-backup` },
+});
+
+new aws.s3.BucketLifecycleConfigurationV2(`${prefix}-backup-lifecycle`, {
+    bucket: backupBucket.id,
+    rules: [{
+        id: "expire-old-backups",
+        status: "Enabled",
+        expiration: { days: 30 },
+    }],
+});
+
+new aws.iam.RolePolicy(`${prefix}-ec2-s3-backup-policy`, {
+    name: `${prefix}-ec2-s3-backup-policy`,
+    role: ec2Role.id,
+    policy: backupBucket.arn.apply(arn => JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Effect: "Allow",
+            Action: ["s3:PutObject", "s3:GetObject", "s3:ListBucket"],
+            Resource: [arn, `${arn}/*`],
+        }],
+    })),
+});
+
 const ec2InstanceProfile = new aws.iam.InstanceProfile(`${prefix}-ec2-profile`, {
     name: `${prefix}-ec2-profile`,
     role: ec2Role.name,
@@ -281,3 +309,4 @@ export const ec2PublicIp = eip.publicIp;
 export const ecrRepositoryUrl = ecrRepo.repositoryUrl;
 export const ecrRepositoryName = ecrRepo.name;
 export const appDomain = appDomainName;
+export const backupBucketName = backupBucket.id;

--- a/src/main/java/team/themoment/readygsmserver/global/config/WebMvcConfig.java
+++ b/src/main/java/team/themoment/readygsmserver/global/config/WebMvcConfig.java
@@ -1,9 +1,12 @@
 package team.themoment.readygsmserver.global.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import team.themoment.readygsmserver.global.security.resolver.AuthenticationArgumentResolver;
 
@@ -16,14 +19,18 @@ public class WebMvcConfig implements WebMvcConfigurer {
     private final CorsProperties corsProperties;
     private final AuthenticationArgumentResolver authenticationArgumentResolver;
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/**")
-                .allowedOrigins(corsProperties.allowedOrigins().toArray(String[]::new))
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
-                .allowedHeaders("*")
-                .allowCredentials(true)
-                .maxAge(3600);
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(corsProperties.allowedOrigins());
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration);
+        return source;
     }
 
     @Override


### PR DESCRIPTION
## 개요

운영 중 발생할 수 있는 DB 장애·실수에 대비해 MySQL 데이터를 매일 S3에 자동 백업하는 구조를 추가했습니다.
EC2 인스턴스의 IAM Role을 활용해 별도 자격증명 없이 S3에 업로드하며, 배포 시 cron job이 자동 등록됩니다.

## 변경 사항

- `infra/index.ts` — S3 백업 버킷 및 EC2 IAM Role에 S3 접근 정책 추가 (30일 수명 주기 설정 포함)
- `deploy/backup-mysql.sh` — mysqldump 실행 후 S3에 업로드하는 백업 스크립트 추가
- `.github/workflows/readygsm-prod-cd.yml` — 배포 시 백업 스크립트를 EC2에 전송하고 cron job 자동 등록 (매일 새벽 3시)
- `src/.../WebMvcConfig.java` — CORS 설정을 `CorsConfigurationSource` Bean 방식으로 변경
- `build.gradle` — 릴리즈 버전 갱신 (`v20260626.0` → `v20260626.1`)

## 참고

- S3 버킷은 `pulumi destroy` 시 함께 삭제됩니다 (운영 중 장애 대응 목적의 백업이므로 의도된 동작)
- 복원 명령어: `gunzip < backup.sql.gz | docker exec -i readygsm-mysql mysql -u root -p readygsm`