### PR TITLE
[application] 엑셀 다운로드 `Content-Disposition`에 `filename`과 `filename*` 모두 포함

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +22,6 @@ import team.themoment.readygsmserver.domain.application.service.QueryApplication
 import team.themoment.readygsmserver.domain.application.service.QueryMyApplicationsService;
 import team.themoment.readygsmserver.global.security.annotation.AuthRequest;
 
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -106,12 +106,13 @@ public class ApplicationController {
     public ResponseEntity<byte[]> exportExcel(@RequestParam Long activityId) {
         ExcelExportResDto result = exportApplicationExcelService.execute(activityId);
 
-        String encodedFileName = URLEncoder.encode(result.fileName(), StandardCharsets.UTF_8).replace("+", "%20");
-        String contentDisposition = "attachment; filename=\"" + encodedFileName + "\"; filename*=UTF-8''" + encodedFileName;
-
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
-        headers.add(HttpHeaders.CONTENT_DISPOSITION, contentDisposition);
+        headers.setContentDisposition(
+                ContentDisposition.attachment()
+                        .filename(result.fileName(), StandardCharsets.UTF_8)
+                        .build()
+        );
 
         return ResponseEntity.ok().headers(headers).body(result.content());
     }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/controller/ApplicationController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +21,7 @@ import team.themoment.readygsmserver.domain.application.service.QueryApplication
 import team.themoment.readygsmserver.domain.application.service.QueryMyApplicationsService;
 import team.themoment.readygsmserver.global.security.annotation.AuthRequest;
 
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -106,11 +106,12 @@ public class ApplicationController {
     public ResponseEntity<byte[]> exportExcel(@RequestParam Long activityId) {
         ExcelExportResDto result = exportApplicationExcelService.execute(activityId);
 
+        String encodedFileName = URLEncoder.encode(result.fileName(), StandardCharsets.UTF_8).replace("+", "%20");
+        String contentDisposition = "attachment; filename=\"" + encodedFileName + "\"; filename*=UTF-8''" + encodedFileName;
+
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
-        headers.setContentDisposition(
-                ContentDisposition.attachment().filename(result.fileName(), StandardCharsets.UTF_8).build()
-        );
+        headers.add(HttpHeaders.CONTENT_DISPOSITION, contentDisposition);
 
         return ResponseEntity.ok().headers(headers).body(result.content());
     }


### PR DESCRIPTION
## 개요

`Content-Disposition` 헤더에 `filename*`만 포함하던 방식이 일부 클라이언트에서 파일명이 적용되지 않는 문제를 수정하였습니다. RFC 6266에 따라 `filename`과 `filename*`을 모두 포함하도록 변경하였습니다.

## 변경 사항

### `Content-Disposition` 헤더 구성 방식 변경

- 기존: `ContentDisposition.attachment().filename(name, UTF-8).build()` → `filename*=UTF-8''...`만 내려감
- 변경: `filename="..."` (구형 클라이언트 호환) + `filename*=UTF-8''...` (RFC 5987, 한글 지원) 둘 다 포함
- `URLEncoder`로 파일명을 퍼센트 인코딩하고 공백 인코딩을 `+` 대신 `%20`으로 처리하였습니다.

변경 후 헤더 예시:
```
Content-Disposition: attachment; filename="%ED%99%9C%EB%8F%99%EB%AA%85-20260626_123456.xlsx"; filename*=UTF-8''%ED%99%9C%EB%8F%99%EB%AA%85-20260626_123456.xlsx
```
