### PR TITLE
update(application): 예비인원 최대 3명 제한 추가

### DIFF
--- a/src/main/java/team/themoment/readygsmserver/domain/application/dto/response/ApplicationResDto.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/dto/response/ApplicationResDto.java
@@ -13,9 +13,10 @@ public record ApplicationResDto(
         String schoolName,
         String phoneNumber,
         String familyPhoneNumber,
-        boolean isReserve
+        boolean isReserve,
+        Integer reserveOrder
 ) {
-    public static ApplicationResDto from(ApplicationJpaEntity entity) {
+    public static ApplicationResDto from(ApplicationJpaEntity entity, Integer reserveOrder) {
         return new ApplicationResDto(
                 entity.getId(),
                 entity.getActivity().getId(),
@@ -27,7 +28,8 @@ public record ApplicationResDto(
                 entity.getSchoolName(),
                 entity.getPhoneNumber(),
                 entity.getFamilyPhoneNumber(),
-                entity.isReserve()
+                entity.isReserve(),
+                reserveOrder
         );
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
@@ -14,7 +14,6 @@ public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntit
     boolean existsByUser_Id(Long userId);
     long countByActivity_Id(Long activityId);
     long countByActivity_IdAndIsReserve(Long activityId, boolean isReserve);
-    boolean existsByActivity_IdAndIsReserve(Long activityId, boolean isReserve);
     @EntityGraph(attributePaths = {"activity"})
     Optional<ApplicationJpaEntity> findByActivity_IdAndUser_Id(Long activityId, Long userId);
     Optional<ApplicationJpaEntity> findFirstByActivity_IdAndIsReserveTrueOrderByCreatedAtAscIdAsc(Long activityId);

--- a/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/repository/ApplicationRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,6 +18,10 @@ public interface ApplicationRepository extends JpaRepository<ApplicationJpaEntit
     @EntityGraph(attributePaths = {"activity"})
     Optional<ApplicationJpaEntity> findByActivity_IdAndUser_Id(Long activityId, Long userId);
     Optional<ApplicationJpaEntity> findFirstByActivity_IdAndIsReserveTrueOrderByCreatedAtAscIdAsc(Long activityId);
+
+    @Query("SELECT COUNT(a) FROM ApplicationJpaEntity a WHERE a.activity.id = :activityId AND a.isReserve = true " +
+            "AND (a.createdAt < :createdAt OR (a.createdAt = :createdAt AND a.id < :id))")
+    long countReserveApplicantsAheadOf(@Param("activityId") Long activityId, @Param("createdAt") LocalDateTime createdAt, @Param("id") Long id);
 
     @Query("SELECT app.activity.id, COUNT(app) FROM ApplicationJpaEntity app GROUP BY app.activity.id")
     List<Object[]> countApplicantsGroupedByActivity();

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
@@ -22,6 +22,8 @@ import java.time.LocalDateTime;
 @Transactional
 public class ApplyActivityService {
 
+    private static final int MAX_RESERVE_APPLICANT = 3;
+
     private final ApplicationRepository applicationRepository;
     private final ActivityRepository activityRepository;
     private final UserRepository userRepository;
@@ -45,8 +47,12 @@ public class ApplyActivityService {
         }
 
         long currentMainApplicants = applicationRepository.countByActivity_IdAndIsReserve(activityId, false);
-        boolean hasReserve = applicationRepository.existsByActivity_IdAndIsReserve(activityId, true);
-        boolean isReserve = currentMainApplicants >= activity.getMaxApplicant() || hasReserve;
+        long currentReserveApplicants = applicationRepository.countByActivity_IdAndIsReserve(activityId, true);
+        boolean isReserve = currentMainApplicants >= activity.getMaxApplicant() || currentReserveApplicants > 0;
+
+        if (isReserve && currentReserveApplicants >= MAX_RESERVE_APPLICANT) {
+            throw new ExpectedException("예비인원이 마감되었습니다.", HttpStatus.CONFLICT);
+        }
 
         ApplicationJpaEntity saved = applicationRepository.save(
                 ApplicationJpaEntity.builder()

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityService.java
@@ -69,6 +69,7 @@ public class ApplyActivityService {
                         .build()
         );
 
-        return ApplicationResDto.from(saved);
+        Integer reserveOrder = isReserve ? (int) currentReserveApplicants + 1 : null;
+        return ApplicationResDto.from(saved, reserveOrder);
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/QueryApplicationsService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/QueryApplicationsService.java
@@ -4,9 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.readygsmserver.domain.application.dto.response.ApplicationResDto;
+import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
 import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
 
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -16,8 +20,16 @@ public class QueryApplicationsService {
     private final ApplicationRepository applicationRepository;
 
     public List<ApplicationResDto> execute(Long activityId) {
-        return applicationRepository.findAllByActivity_Id(activityId).stream()
-                .map(ApplicationResDto::from)
+        List<ApplicationJpaEntity> applications = applicationRepository.findAllByActivity_Id(activityId);
+
+        Map<Long, Integer> reserveOrderById = new HashMap<>();
+        applications.stream()
+                .filter(ApplicationJpaEntity::isReserve)
+                .sorted(Comparator.comparing(ApplicationJpaEntity::getCreatedAt).thenComparing(ApplicationJpaEntity::getId))
+                .forEach(app -> reserveOrderById.put(app.getId(), reserveOrderById.size() + 1));
+
+        return applications.stream()
+                .map(app -> ApplicationResDto.from(app, reserveOrderById.get(app.getId())))
                 .toList();
     }
 }

--- a/src/main/java/team/themoment/readygsmserver/domain/application/service/QueryMyApplicationsService.java
+++ b/src/main/java/team/themoment/readygsmserver/domain/application/service/QueryMyApplicationsService.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.readygsmserver.domain.application.dto.response.ApplicationResDto;
+import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
 import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
@@ -16,8 +17,16 @@ public class QueryMyApplicationsService {
     private final ApplicationRepository applicationRepository;
 
     public ApplicationResDto execute(Long userId) {
-        return applicationRepository.findByUser_Id(userId)
-                .map(ApplicationResDto::from)
+        ApplicationJpaEntity application = applicationRepository.findByUser_Id(userId)
                 .orElseThrow(() -> new ExpectedException("신청 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        Integer reserveOrder = null;
+        if (application.isReserve()) {
+            long aheadCount = applicationRepository.countReserveApplicantsAheadOf(
+                    application.getActivity().getId(), application.getCreatedAt(), application.getId());
+            reserveOrder = (int) aheadCount + 1;
+        }
+
+        return ApplicationResDto.from(application, reserveOrder);
     }
 }

--- a/src/test/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityServiceTest.java
+++ b/src/test/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityServiceTest.java
@@ -1,0 +1,118 @@
+package team.themoment.readygsmserver.domain.application.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
+import team.themoment.readygsmserver.domain.activity.repository.ActivityRepository;
+import team.themoment.readygsmserver.domain.application.dto.request.ApplicationReqDto;
+import team.themoment.readygsmserver.domain.application.dto.response.ApplicationResDto;
+import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
+import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
+import team.themoment.readygsmserver.domain.user.entity.UserJpaEntity;
+import team.themoment.readygsmserver.domain.user.entity.constant.Role;
+import team.themoment.readygsmserver.domain.user.repository.UserRepository;
+import team.themoment.sdk.exception.ExpectedException;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApplyActivityServiceTest {
+
+    private static final Long ACTIVITY_ID = 1L;
+    private static final Long USER_ID = 1L;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+    @Mock
+    private ActivityRepository activityRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ApplyActivityService applyActivityService;
+
+    private ApplicationReqDto req;
+
+    @BeforeEach
+    void setUp() {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        ActivityJpaEntity activity = ActivityJpaEntity.builder()
+                .id(ACTIVITY_ID)
+                .name("체험")
+                .place("장소")
+                .description("설명")
+                .maxApplicant(2)
+                .activityDate(now.toLocalDate())
+                .registrationStartAt(now.minusDays(1))
+                .registrationEndAt(now.plusDays(1))
+                .activityStartTime(now.toLocalTime())
+                .activityEndTime(now.toLocalTime().plusHours(1))
+                .build();
+
+        UserJpaEntity user = UserJpaEntity.builder()
+                .id(USER_ID)
+                .role(Role.USER)
+                .build();
+
+        req = new ApplicationReqDto(
+                "홍길동", 1, 1, 1, "광주소프트웨어마이스터고", "010-1234-5678", "010-8765-4321"
+        );
+
+        when(activityRepository.findByIdWithLock(ACTIVITY_ID)).thenReturn(Optional.of(activity));
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(applicationRepository.existsByUser_Id(USER_ID)).thenReturn(false);
+        lenient().when(applicationRepository.save(any(ApplicationJpaEntity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void 정원이_남아있으면_확정으로_저장된다() {
+        when(applicationRepository.countByActivity_IdAndIsReserve(ACTIVITY_ID, false)).thenReturn(0L);
+        when(applicationRepository.countByActivity_IdAndIsReserve(ACTIVITY_ID, true)).thenReturn(0L);
+
+        ApplicationResDto result = applyActivityService.execute(USER_ID, ACTIVITY_ID, req);
+
+        assertThat(result.isReserve()).isFalse();
+    }
+
+    @Test
+    void 예비인원이_3명_미만이면_예비인원으로_저장된다() {
+        when(applicationRepository.countByActivity_IdAndIsReserve(ACTIVITY_ID, false)).thenReturn(2L);
+        when(applicationRepository.countByActivity_IdAndIsReserve(ACTIVITY_ID, true)).thenReturn(2L);
+
+        ApplicationResDto result = applyActivityService.execute(USER_ID, ACTIVITY_ID, req);
+
+        assertThat(result.isReserve()).isTrue();
+        verify(applicationRepository).save(any(ApplicationJpaEntity.class));
+    }
+
+    @Test
+    void 예비인원이_3명이면_추가_신청은_예외가_발생한다() {
+        when(applicationRepository.countByActivity_IdAndIsReserve(ACTIVITY_ID, false)).thenReturn(2L);
+        when(applicationRepository.countByActivity_IdAndIsReserve(ACTIVITY_ID, true)).thenReturn(3L);
+
+        assertThatThrownBy(() -> applyActivityService.execute(USER_ID, ACTIVITY_ID, req))
+                .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.throwable(ExpectedException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+                    assertThat(ex.getMessage()).isEqualTo("예비인원이 마감되었습니다.");
+                });
+
+        verify(applicationRepository, never()).save(any());
+    }
+}

--- a/src/test/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityServiceTest.java
+++ b/src/test/java/team/themoment/readygsmserver/domain/application/service/ApplyActivityServiceTest.java
@@ -88,6 +88,7 @@ class ApplyActivityServiceTest {
         ApplicationResDto result = applyActivityService.execute(USER_ID, ACTIVITY_ID, req);
 
         assertThat(result.isReserve()).isFalse();
+        assertThat(result.reserveOrder()).isNull();
     }
 
     @Test
@@ -98,6 +99,7 @@ class ApplyActivityServiceTest {
         ApplicationResDto result = applyActivityService.execute(USER_ID, ACTIVITY_ID, req);
 
         assertThat(result.isReserve()).isTrue();
+        assertThat(result.reserveOrder()).isEqualTo(3);
         verify(applicationRepository).save(any(ApplicationJpaEntity.class));
     }
 

--- a/src/test/java/team/themoment/readygsmserver/domain/application/service/QueryApplicationsServiceTest.java
+++ b/src/test/java/team/themoment/readygsmserver/domain/application/service/QueryApplicationsServiceTest.java
@@ -1,0 +1,67 @@
+package team.themoment.readygsmserver.domain.application.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
+import team.themoment.readygsmserver.domain.application.dto.response.ApplicationResDto;
+import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
+import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
+import team.themoment.readygsmserver.domain.user.entity.UserJpaEntity;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QueryApplicationsServiceTest {
+
+    private static final Long ACTIVITY_ID = 1L;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @InjectMocks
+    private QueryApplicationsService queryApplicationsService;
+
+    @Test
+    void 예비인원들의_reserveOrder는_신청_순서대로_매겨진다() {
+        ActivityJpaEntity activity = ActivityJpaEntity.builder().id(ACTIVITY_ID).build();
+        LocalDateTime baseTime = LocalDateTime.now();
+
+        ApplicationJpaEntity confirmed = applicationOf(activity, 1L, false, baseTime.minusMinutes(10));
+        ApplicationJpaEntity reserveFirst = applicationOf(activity, 2L, true, baseTime.minusMinutes(5));
+        ApplicationJpaEntity reserveSecond = applicationOf(activity, 3L, true, baseTime.minusMinutes(3));
+        ApplicationJpaEntity reserveThird = applicationOf(activity, 4L, true, baseTime.minusMinutes(1));
+
+        when(applicationRepository.findAllByActivity_Id(ACTIVITY_ID))
+                .thenReturn(List.of(confirmed, reserveThird, reserveFirst, reserveSecond));
+
+        List<ApplicationResDto> result = queryApplicationsService.execute(ACTIVITY_ID);
+
+        Map<Long, Integer> reserveOrderById = new HashMap<>();
+        result.forEach(dto -> reserveOrderById.put(dto.id(), dto.reserveOrder()));
+
+        assertThat(reserveOrderById.get(1L)).isNull();
+        assertThat(reserveOrderById.get(2L)).isEqualTo(1);
+        assertThat(reserveOrderById.get(3L)).isEqualTo(2);
+        assertThat(reserveOrderById.get(4L)).isEqualTo(3);
+    }
+
+    private ApplicationJpaEntity applicationOf(ActivityJpaEntity activity, Long id, boolean isReserve, LocalDateTime createdAt) {
+        UserJpaEntity user = UserJpaEntity.builder().id(id).build();
+        return ApplicationJpaEntity.builder()
+                .id(id)
+                .activity(activity)
+                .user(user)
+                .isReserve(isReserve)
+                .createdAt(createdAt)
+                .build();
+    }
+}

--- a/src/test/java/team/themoment/readygsmserver/domain/application/service/QueryMyApplicationsServiceTest.java
+++ b/src/test/java/team/themoment/readygsmserver/domain/application/service/QueryMyApplicationsServiceTest.java
@@ -1,0 +1,91 @@
+package team.themoment.readygsmserver.domain.application.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.readygsmserver.domain.activity.entity.ActivityJpaEntity;
+import team.themoment.readygsmserver.domain.application.dto.response.ApplicationResDto;
+import team.themoment.readygsmserver.domain.application.entity.ApplicationJpaEntity;
+import team.themoment.readygsmserver.domain.application.repository.ApplicationRepository;
+import team.themoment.readygsmserver.domain.user.entity.UserJpaEntity;
+import team.themoment.sdk.exception.ExpectedException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QueryMyApplicationsServiceTest {
+
+    private static final Long ACTIVITY_ID = 1L;
+    private static final Long USER_ID = 1L;
+    private static final Long APPLICATION_ID = 10L;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @InjectMocks
+    private QueryMyApplicationsService queryMyApplicationsService;
+
+    private ActivityJpaEntity activity;
+    private UserJpaEntity user;
+    private LocalDateTime createdAt;
+
+    @BeforeEach
+    void setUp() {
+        activity = ActivityJpaEntity.builder().id(ACTIVITY_ID).build();
+        user = UserJpaEntity.builder().id(USER_ID).build();
+        createdAt = LocalDateTime.now();
+    }
+
+    @Test
+    void 확정된_신청은_reserveOrder가_없다() {
+        ApplicationJpaEntity application = ApplicationJpaEntity.builder()
+                .id(APPLICATION_ID)
+                .activity(activity)
+                .user(user)
+                .isReserve(false)
+                .createdAt(createdAt)
+                .build();
+        when(applicationRepository.findByUser_Id(USER_ID)).thenReturn(Optional.of(application));
+
+        ApplicationResDto result = queryMyApplicationsService.execute(USER_ID);
+
+        assertThat(result.isReserve()).isFalse();
+        assertThat(result.reserveOrder()).isNull();
+    }
+
+    @Test
+    void 예비인원은_앞에_대기중인_인원_수_1을_reserveOrder로_받는다() {
+        ApplicationJpaEntity application = ApplicationJpaEntity.builder()
+                .id(APPLICATION_ID)
+                .activity(activity)
+                .user(user)
+                .isReserve(true)
+                .createdAt(createdAt)
+                .build();
+        when(applicationRepository.findByUser_Id(USER_ID)).thenReturn(Optional.of(application));
+        when(applicationRepository.countReserveApplicantsAheadOf(eq(ACTIVITY_ID), eq(createdAt), eq(APPLICATION_ID)))
+                .thenReturn(1L);
+
+        ApplicationResDto result = queryMyApplicationsService.execute(USER_ID);
+
+        assertThat(result.isReserve()).isTrue();
+        assertThat(result.reserveOrder()).isEqualTo(2);
+    }
+
+    @Test
+    void 신청_내역이_없으면_예외가_발생한다() {
+        when(applicationRepository.findByUser_Id(USER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> queryMyApplicationsService.execute(USER_ID))
+                .isInstanceOf(ExpectedException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- 학과체험 신청 시 예비인원(대기)이 무제한으로 쌓이던 문제를 수정
- 예비인원은 최대 3명까지만 받도록 제한하고, 초과 시 409 Conflict + "예비인원이 마감되었습니다." 예외를 반환
- 더 이상 사용되지 않는 `existsByActivity_IdAndIsReserve` 리포지토리 메서드 제거

## Test plan
- [x] `./gradlew compileJava` 빌드 성공 확인
- [ ] `/v1/application/apply` 엔드포인트로 정원 초과 + 예비 3명 초과 시나리오 수동 확인 (기존에 관련 테스트 코드 없음)

https://claude.ai/code/session_01TGGeXgX2ACR6gM3fiyT93j