### PR TITLE
[global] redis command exec form으로 변경

### DIFF
--- a/deploy/compose.stage.yml
+++ b/deploy/compose.stage.yml
@@ -49,10 +49,7 @@ services:
   redis:
     image: redis:7-alpine
     container_name: readygsm-redis
-    command: >
-      redis-server
-      --requirepass ${STAGE_REDIS_PASSWORD}
-      --appendonly yes
+    command: ["redis-server", "--requirepass", "${STAGE_REDIS_PASSWORD}", "--appendonly", "yes"]
     volumes:
       - redis_data:/data
     healthcheck:


### PR DESCRIPTION
## Summary
- #111 머지 후 두 번째 Stage CD 실행이 `services[redis].command' invalid command line string` 오류로 실패
- 원인: redis 서비스의 `command`가 YAML 문자열(shell string) 형태라, `${STAGE_REDIS_PASSWORD}` 치환 후 docker compose가 전체 문자열을 셸처럼 토큰화하다 실패 (비밀번호에 셸 특수문자가 있으면 깨지는 것과 동일한 계열의 문제)
- `command`를 리스트(exec form)로 변경하여 셸 파싱 자체를 제거

## Test plan
- [ ] develop 머지 후 Stage CD workflow 정상 동작 확인
- [ ] `http://service.gsmsv.site:28118` 접속 확인

https://claude.ai/code/session_01CTUBFJSVpGdQXhKysVKxSx