### PR TITLE
[global] stage 환경에 HTTPS(nginx + Let's Encrypt) 구성 추가

### DIFF
--- a/.github/workflows/readygsm-stage-cd.yml
+++ b/.github/workflows/readygsm-stage-cd.yml
@@ -38,7 +38,7 @@ jobs:
           username: ${{ env.GSMSV_USER }}
           key: ${{ secrets.STAGE_SSH_PRIVATE_KEY }}
           port: ${{ secrets.STAGE_SSH_PORT }}
-          source: "deploy/compose.stage.yml,docker/stage.Dockerfile,build/libs/*.jar"
+          source: "deploy/compose.stage.yml,docker/stage.Dockerfile,docker/nginx-stage.conf,build/libs/*.jar"
           target: "${{ env.DEPLOY_DIR }}-files/"
 
       - name: Deploy to GSMSV VM
@@ -52,9 +52,10 @@ jobs:
           script: |
             set -e
 
-            mkdir -p $HOME/readygsm-stage/docker $HOME/readygsm-stage/build/libs
+            mkdir -p $HOME/readygsm-stage/docker $HOME/readygsm-stage/build/libs $HOME/readygsm-stage/nginx
             cp $HOME/readygsm-stage-files/deploy/compose.stage.yml $HOME/readygsm-stage/compose.stage.yml
             cp $HOME/readygsm-stage-files/docker/stage.Dockerfile $HOME/readygsm-stage/docker/stage.Dockerfile
+            cp $HOME/readygsm-stage-files/docker/nginx-stage.conf $HOME/readygsm-stage/nginx/stage.conf
             cp $HOME/readygsm-stage-files/build/libs/*.jar $HOME/readygsm-stage/build/libs/
 
             cd $HOME/readygsm-stage

--- a/deploy/compose.stage.yml
+++ b/deploy/compose.stage.yml
@@ -1,11 +1,33 @@
 services:
+  nginx:
+    image: nginx:alpine
+    container_name: readygsm-stage-nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/stage.conf:/etc/nginx/conf.d/default.conf:ro
+      - certbot_conf:/etc/nginx/certs:ro
+      - certbot_www:/var/www/certbot:ro
+    depends_on:
+      - app
+    restart: always
+    networks:
+      - gsmsv-net
+
+  certbot:
+    image: certbot/certbot
+    container_name: readygsm-stage-certbot
+    volumes:
+      - certbot_conf:/etc/letsencrypt
+      - certbot_www:/var/www/certbot
+    entrypoint: "true"
+
   app:
     build:
       context: .
       dockerfile: docker/stage.Dockerfile
     container_name: readygsm-app
-    ports:
-      - "80:8080"
     environment:
       - MYSQL_HOST=mysql
       - MYSQL_USERNAME=${STAGE_MYSQL_USERNAME}
@@ -65,6 +87,10 @@ volumes:
   mysql_data:
     driver: local
   redis_data:
+    driver: local
+  certbot_conf:
+    driver: local
+  certbot_www:
     driver: local
 
 networks:

--- a/deploy/compose.stage.yml
+++ b/deploy/compose.stage.yml
@@ -8,7 +8,6 @@ services:
     volumes:
       - ./nginx/stage.conf:/etc/nginx/conf.d/default.conf:ro
       - certbot_conf:/etc/nginx/certs:ro
-      - certbot_www:/var/www/certbot:ro
     depends_on:
       - app
     restart: always
@@ -16,11 +15,10 @@ services:
       - gsmsv-net
 
   certbot:
-    image: certbot/certbot
+    image: certbot/dns-route53
     container_name: readygsm-stage-certbot
     volumes:
       - certbot_conf:/etc/letsencrypt
-      - certbot_www:/var/www/certbot
     entrypoint: "true"
 
   app:
@@ -89,8 +87,6 @@ volumes:
   redis_data:
     driver: local
   certbot_conf:
-    driver: local
-  certbot_www:
     driver: local
 
 networks:

--- a/docker/nginx-stage.conf
+++ b/docker/nginx-stage.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80;
+    server_name stage.readygsm.kr;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name stage.readygsm.kr;
+
+    ssl_certificate     /etc/nginx/certs/live/stage.readygsm.kr/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/live/stage.readygsm.kr/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+
+    location / {
+        proxy_pass         http://app:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto https;
+    }
+}

--- a/docker/nginx-stage.conf
+++ b/docker/nginx-stage.conf
@@ -1,22 +1,22 @@
 server {
     listen 80;
-    server_name stage.readygsm.kr;
-
-    location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
-    }
+    server_name stage.hellogsm.kr;
 
     location / {
-        return 301 https://$host$request_uri;
+        proxy_pass         http://app:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto http;
     }
 }
 
 server {
     listen 443 ssl;
-    server_name stage.readygsm.kr;
+    server_name stage.hellogsm.kr;
 
-    ssl_certificate     /etc/nginx/certs/live/stage.readygsm.kr/fullchain.pem;
-    ssl_certificate_key /etc/nginx/certs/live/stage.readygsm.kr/privkey.pem;
+    ssl_certificate     /etc/nginx/certs/live/stage.hellogsm.kr/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/live/stage.hellogsm.kr/privkey.pem;
     ssl_protocols       TLSv1.2 TLSv1.3;
     ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;

--- a/docker/nginx-stage.conf
+++ b/docker/nginx-stage.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name stage.hellogsm.kr;
+    server_name api.stage.ready.hellogsm.kr;
 
     location / {
         proxy_pass         http://app:8080;
@@ -13,10 +13,10 @@ server {
 
 server {
     listen 443 ssl;
-    server_name stage.hellogsm.kr;
+    server_name api.stage.ready.hellogsm.kr;
 
-    ssl_certificate     /etc/nginx/certs/live/stage.hellogsm.kr/fullchain.pem;
-    ssl_certificate_key /etc/nginx/certs/live/stage.hellogsm.kr/privkey.pem;
+    ssl_certificate     /etc/nginx/certs/live/api.stage.ready.hellogsm.kr/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/live/api.stage.ready.hellogsm.kr/privkey.pem;
     ssl_protocols       TLSv1.2 TLSv1.3;
     ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;


### PR DESCRIPTION
## Summary
- stage 배포에 nginx + certbot(DNS-01, Route53)을 추가하여 HTTPS 지원
- 도메인: `api.stage.ready.hellogsm.kr` (GSMSV `service.gsmsv.site`로 CNAME 연결, 이미 DNS 전파 확인 완료)
- GSMSV는 NAT 포트포워딩 구조라 HTTP-01 챌린지가 불가능하여 DNS-01 방식 채택 (Route53 API 사용)
- `app`은 더 이상 호스트 포트를 직접 열지 않고 nginx가 80/443을 전담, `app:8080`으로 리버스 프록시
- 외부 접속: HTTP `service.gsmsv.site:28118`(내부 80), HTTPS `service.gsmsv.site:31308`(내부 443) — 포트가 표준이 아니라 강제 리다이렉트 없이 둘 다 직접 접근 가능하도록 구성
- DNS-01 갱신용으로 Route53 `hellogsm.kr` 존의 TXT 레코드만 변경 가능한 최소권한 IAM 사용자(`readygsm-stage-certbot-dns01`)를 별도로 생성함 (기존 prod용 광범위 자격증명과 분리)

## Test plan
- [ ] 머지 후 Stage CD 배포로 nginx/certbot 컨테이너 정상 기동 확인 (인증서는 아직 없는 상태)
- [ ] VM에서 최초 인증서 발급: `docker compose -f compose.stage.yml run --rm -e AWS_ACCESS_KEY_ID=... -e AWS_SECRET_ACCESS_KEY=... certbot certonly --dns-route53 -d api.stage.ready.hellogsm.kr --email <이메일> --agree-tos --no-eff-email`
- [ ] `docker compose -f compose.stage.yml restart nginx` 후 `https://api.stage.ready.hellogsm.kr:31308` 정상 접속 확인
- [ ] Google/Kakao OAuth 콘솔에 새 콜백 URL 등록 확인
- [ ] 인증서 자동 갱신 크론 설정

https://claude.ai/code/session_01CTUBFJSVpGdQXhKysVKxSx